### PR TITLE
merge to superset optimizations

### DIFF
--- a/bitmap_opt.go
+++ b/bitmap_opt.go
@@ -1,0 +1,135 @@
+package sroar
+
+// AndToSuperset calculates intersection of current and incoming bitmap
+// It reuses containers present in current bitmap
+// and utilize container buffer provided.
+//
+// CAUTION: should be used only when current bitmap contained before
+// all elements present in incoming bitmap
+func (dst *Bitmap) AndToSuperset(src *Bitmap, containerBuf []uint16) {
+	if src == nil {
+		for ai, an := 0, dst.keys.numKeys(); ai < an; ai++ {
+			off := dst.keys.val(ai)
+			zeroOutContainer(dst.getContainer(off))
+		}
+		return
+	}
+
+	a, b := dst, src
+	ai, an := 0, a.keys.numKeys()
+	bi, bn := 0, b.keys.numKeys()
+
+	for ai < an && bi < bn {
+		ak := a.keys.key(ai)
+		bk := b.keys.key(bi)
+		if ak == bk {
+			off := a.keys.val(ai)
+			ac := a.getContainer(off)
+			off = b.keys.val(bi)
+			bc := b.getContainer(off)
+
+			if getCardinality(bc) == 0 {
+				zeroOutContainer(ac)
+			} else {
+				containerAndToSuperset(ac, bc, containerBuf)
+			}
+			ai++
+			bi++
+		} else if ak < bk {
+			off := a.keys.val(ai)
+			zeroOutContainer(a.getContainer(off))
+			ai++
+		} else {
+			bi++
+		}
+	}
+	for ; ai < an; ai++ {
+		off := a.keys.val(ai)
+		zeroOutContainer(a.getContainer(off))
+	}
+}
+
+// OrToSuperset calculates union of current and incoming bitmap
+// It reuses containers present in current bitmap
+// and utilize container buffer provided.
+//
+// CAUTION: should be used only when current bitmap contained before
+// all elements present in incoming bitmap
+func (dst *Bitmap) OrToSuperset(src *Bitmap, containerBuf []uint16) {
+	if src == nil {
+		return
+	}
+
+	srcIdx, numKeys := 0, src.keys.numKeys()
+	for ; srcIdx < numKeys; srcIdx++ {
+		srcCont := src.getContainer(src.keys.val(srcIdx))
+		if getCardinality(srcCont) == 0 {
+			continue
+		}
+
+		key := src.keys.key(srcIdx)
+
+		dstIdx := dst.keys.search(key)
+		if dstIdx >= dst.keys.numKeys() || dst.keys.key(dstIdx) != key {
+			// Container does not exist in dst.
+			panic("Current bitmap should have all containers of incoming bitmap")
+		} else {
+			// Container exists in dst as well. Do an inline containerOr.
+			offset := dst.keys.val(dstIdx)
+			dstCont := dst.getContainer(offset)
+			containerOrToSuperset(dstCont, srcCont, containerBuf)
+		}
+	}
+}
+
+// AndNotToSuperset calculates difference between current and incoming bitmap
+// It reuses containers present in current bitmap
+// and utilize container buffer provided.
+//
+// CAUTION: should be used only when current bitmap contained before
+// all elements present in incoming bitmap
+func (dst *Bitmap) AndNotToSuperset(src *Bitmap, containerBuf []uint16) {
+	if src == nil {
+		return
+	}
+
+	a, b := dst, src
+	ai, an := 0, a.keys.numKeys()
+	bi, bn := 0, b.keys.numKeys()
+
+	for ai < an && bi < bn {
+		ak := a.keys.key(ai)
+		bk := b.keys.key(bi)
+		if ak == bk {
+			off := a.keys.val(ai)
+			ac := a.getContainer(off)
+			off = b.keys.val(bi)
+			bc := b.getContainer(off)
+
+			if getCardinality(bc) != 0 {
+				containerAndNotToSuperset(ac, bc, containerBuf)
+			}
+			ai++
+			bi++
+		} else if ak < bk {
+			ai++
+		} else {
+			bi++
+		}
+	}
+}
+
+func (ra *Bitmap) ConvertToBitmapContainers() {
+	for ai, an := 0, ra.keys.numKeys(); ai < an; ai++ {
+		ak := ra.keys.key(ai)
+		off := ra.keys.val(ai)
+		ac := ra.getContainer(off)
+
+		if ac[indexType] == typeArray {
+			c := array(ac).toBitmapContainer(nil)
+			offset := ra.newContainer(uint16(len(c)))
+			copy(ra.data[offset:], c)
+			ra.setKey(ak, offset)
+		}
+	}
+}

--- a/bitmap_opt_test.go
+++ b/bitmap_opt_test.go
@@ -1,0 +1,156 @@
+package sroar
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeToSuperset(t *testing.T) {
+	containerThreshold := uint64(math.MaxUint16 + 1)
+	buf := make([]uint16, maxContainerSize)
+
+	// containers of type array + bitmap + bitmap
+	superset := NewBitmap()
+	// containers of type array + array + bitmap
+	and := NewBitmap()
+	or := NewBitmap()
+	andNot := NewBitmap()
+
+	t.Run("init bitmaps", func(t *testing.T) {
+		N1 := uint64(4000)  // fits to array container
+		N2 := uint64(16000) // fits to bitmap container
+
+		// containers of type array for all BMs
+		for i := uint64(0); i < N1; i++ {
+			val1 := i * 2
+
+			superset.Set(val1)
+			if i%3 != 0 {
+				and.Set(i)
+			}
+			if i < N1*3/4 {
+				or.Set(i)
+			}
+			if i%2 == 0 {
+				andNot.Set(i)
+			}
+		}
+
+		// containers of type 2xbitmap for superset
+		// containers of type array+bitmap for subsets
+		for i := uint64(0); i < N2; i++ {
+			val2 := i*3 + containerThreshold
+			val3 := i*4 + 2*containerThreshold
+
+			superset.Set(val2)
+			superset.Set(val3)
+
+			if i%5 == 1 {
+				and.Set(val2)
+			}
+			if a := i % 11; a == 3 || a == 7 {
+				or.Set(val2)
+			}
+			if a := i % 23; a < 5 {
+				andNot.Set(val2)
+			}
+
+			if a := i % 7; a > 3 {
+				and.Set(val3)
+			}
+			if a := i % 13; a < 10 {
+				or.Set(val3)
+			}
+			if a := i % 17; a > 2 && a < 15 {
+				andNot.Set(val3)
+			}
+		}
+	})
+
+	control := superset.Clone()
+
+	t.Run("and", func(t *testing.T) {
+		control.And(and)
+		superset.AndToSuperset(and, buf)
+
+		require.Equal(t, 11389, superset.GetCardinality())
+		require.ElementsMatch(t, control.ToArray(), superset.ToArray())
+	})
+
+	t.Run("or", func(t *testing.T) {
+		control.Or(or)
+		superset.OrToSuperset(or, buf)
+
+		require.Equal(t, 22750, superset.GetCardinality())
+		require.ElementsMatch(t, control.ToArray(), superset.ToArray())
+	})
+
+	t.Run("and not", func(t *testing.T) {
+		control.AndNot(andNot)
+		superset.AndNotToSuperset(andNot, buf)
+
+		require.Equal(t, 9911, superset.GetCardinality())
+		require.ElementsMatch(t, control.ToArray(), superset.ToArray())
+	})
+
+	t.Run("2nd or", func(t *testing.T) {
+		control.Or(or)
+		superset.OrToSuperset(or, buf)
+
+		require.Equal(t, 20730, superset.GetCardinality())
+		require.ElementsMatch(t, control.ToArray(), superset.ToArray())
+	})
+
+	t.Run("2nd and", func(t *testing.T) {
+		control.And(and)
+		superset.AndToSuperset(and, buf)
+
+		require.Equal(t, 10369, superset.GetCardinality())
+		require.ElementsMatch(t, control.ToArray(), superset.ToArray())
+	})
+
+	t.Run("2nd and not", func(t *testing.T) {
+		control.AndNot(andNot)
+		superset.AndNotToSuperset(andNot, buf)
+
+		require.Equal(t, 5520, superset.GetCardinality())
+		require.ElementsMatch(t, control.ToArray(), superset.ToArray())
+	})
+
+	t.Run("merge into", func(t *testing.T) {
+		dst := NewBitmap()
+		for _, val1 := range []uint64{0123, 1234, 2345, 3456, 4567, 5678, 6789, 7890, 8901, 9012} {
+			val2 := val1 + containerThreshold
+			val3 := val1 + 2*containerThreshold
+
+			superset.Set(val1)
+			superset.Set(val2)
+			superset.Set(val3)
+			control.Set(val1)
+			control.Set(val2)
+			control.Set(val3)
+
+			dst.Set(val1)
+			dst.Set(val2)
+			dst.Set(val3)
+		}
+		controlDst := dst.Clone()
+
+		require.Equal(t, 5548, superset.GetCardinality())
+		require.ElementsMatch(t, control.ToArray(), superset.ToArray())
+
+		dst.And(superset)
+		controlDst.And(control)
+
+		require.Equal(t, 30, dst.GetCardinality())
+		require.ElementsMatch(t, controlDst.ToArray(), dst.ToArray())
+
+		dst.Or(superset)
+		controlDst.Or(control)
+
+		require.Equal(t, 5548, dst.GetCardinality())
+		require.ElementsMatch(t, controlDst.ToArray(), dst.ToArray())
+	})
+}

--- a/container_opt.go
+++ b/container_opt.go
@@ -1,0 +1,150 @@
+package sroar
+
+import "math/bits"
+
+func containerAndToSuperset(ac, bc, buf []uint16) []uint16 {
+	at := ac[indexType]
+	bt := bc[indexType]
+
+	if at == typeArray && bt == typeArray {
+		left := array(ac)
+		right := array(bc)
+		return left.andArrayToSuperset(right, buf)
+	}
+	if at == typeBitmap && bt == typeArray {
+		left := bitmap(ac)
+		right := array(bc)
+		return left.andArrayToSuperset(right, buf)
+	}
+	if at == typeBitmap && bt == typeBitmap {
+		left := bitmap(ac)
+		right := bitmap(bc)
+		return left.andBitmapToSuperset(right)
+	}
+	panic("containerAndToSuperset: We should not reach here")
+}
+
+func containerOrToSuperset(ac, bc, buf []uint16) []uint16 {
+	at := ac[indexType]
+	bt := bc[indexType]
+
+	if at == typeArray && bt == typeArray {
+		left := array(ac)
+		right := array(bc)
+		return left.orArrayToSuperset(right, buf)
+	}
+	if at == typeBitmap && bt == typeArray {
+		left := bitmap(ac)
+		right := array(bc)
+		return left.orArray(right, buf, runInline)
+	}
+	if at == typeBitmap && bt == typeBitmap {
+		left := bitmap(ac)
+		right := bitmap(bc)
+		return left.orBitmapToSuperset(right)
+	}
+	panic("containerOrToSuperset: We should not reach here")
+}
+
+func containerAndNotToSuperset(ac, bc, buf []uint16) []uint16 {
+	at := ac[indexType]
+	bt := bc[indexType]
+
+	if at == typeArray && bt == typeArray {
+		left := array(ac)
+		right := array(bc)
+		return left.andNotArrayToSuperset(right, buf)
+	}
+	if at == typeBitmap && bt == typeArray {
+		left := bitmap(ac)
+		right := array(bc)
+		out := left.andNotArray(right)
+		return out
+	}
+	if at == typeBitmap && bt == typeBitmap {
+		left := bitmap(ac)
+		right := bitmap(bc)
+		return left.andNotBitmapToSuperset(right)
+	}
+	panic("containerAndNotToSuperset: We should not reach here")
+}
+
+func (a array) andArrayToSuperset(other array, buf []uint16) []uint16 {
+	copy(buf, zeroContainer)
+	out := buf[:len(a)]
+
+	num := intersection2by2(a.all(), other.all(), out[startIdx:])
+	setCardinality(out, num)
+	copy(a[2:], out[2:])
+	return a
+}
+
+func (a array) orArrayToSuperset(other array, buf []uint16) []uint16 {
+	copy(buf, zeroContainer)
+	out := buf[:len(a)]
+
+	num := union2by2(a.all(), other.all(), out[startIdx:])
+	setCardinality(out, num)
+	copy(a[2:], out[2:])
+	return a
+}
+
+func (a array) andNotArrayToSuperset(other array, buf []uint16) []uint16 {
+	copy(buf, zeroContainer)
+	out := buf[:len(a)]
+
+	andRes := array(a.andArray(other)).all() // TODO is andRes needed?
+	num := difference(a.all(), andRes, out[startIdx:])
+	setCardinality(out, int(num))
+	copy(a[2:], out[2:])
+	return a
+}
+
+func (b bitmap) andBitmapToSuperset(other bitmap) []uint16 {
+	b64 := uint16To64Slice(b[startIdx:])
+	o64 := uint16To64Slice(other[startIdx:])
+
+	var num int
+	for i := range b64 {
+		b64[i] &= o64[i]
+		num += bits.OnesCount64(b64[i])
+	}
+	setCardinality(b, num)
+	return b
+}
+
+func (b bitmap) orBitmapToSuperset(other bitmap) []uint16 {
+	if num := getCardinality(b); num == maxCardinality {
+		// do nothing. bitmap is already full.
+		return b
+	}
+
+	b64 := uint16To64Slice(b[startIdx:])
+	o64 := uint16To64Slice(other[startIdx:])
+
+	var num int
+	for i := range b64 {
+		b64[i] |= o64[i]
+		num += bits.OnesCount64(b64[i])
+	}
+	setCardinality(b, num)
+	return b
+}
+
+func (b bitmap) andArrayToSuperset(other array, buf []uint16) []uint16 {
+	otherb := other.toBitmapContainer(buf)
+	return b.andBitmapToSuperset(otherb)
+}
+
+func (b bitmap) andNotBitmapToSuperset(other bitmap) []uint16 {
+	b64 := uint16To64Slice(b[startIdx:])
+	o64 := uint16To64Slice(other[startIdx:])
+
+	var num int
+	for i := range b64 {
+		b64[i] &^= o64[i]
+		num += bits.OnesCount64(b64[i])
+	}
+	setCardinality(b, num)
+	return b
+}

--- a/utils.go
+++ b/utils.go
@@ -74,7 +74,7 @@ func toByteSlice(b []uint16) []byte {
 // they are pointer-based (unsafe). The caller is responsible to
 // ensure that the input slice does not get garbage collected, deleted
 // or modified while you hold the returned slince.
-////
+// //
 func toUint16Slice(b []byte) (result []uint16) {
 	var u16s []uint16
 	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&u16s))
@@ -84,7 +84,7 @@ func toUint16Slice(b []byte) (result []uint16) {
 	return u16s
 }
 
-// BytesToU32Slice converts the given byte slice to uint32 slice
+// toUint64Slice converts the given byte slice to uint64 slice
 func toUint64Slice(b []uint16) []uint64 {
 	var u64s []uint64
 	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&u64s))
@@ -103,4 +103,24 @@ func Memclr(b []uint16) {
 	}
 	p := unsafe.Pointer(&b[0])
 	memclrNoHeapPointers(p, uintptr(len(b)))
+}
+
+// uint16To64Slice converts the given uint16 slice to uint64 slice
+func uint16To64Slice(u16s []uint16) (result []uint64) {
+	var u64s []uint64
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&u64s))
+	hdr.Len = len(u16s) / 4
+	hdr.Cap = hdr.Len
+	hdr.Data = uintptr(unsafe.Pointer(&u16s[0]))
+	return u64s
+}
+
+// uint64To16Slice converts the given uint64 slice to uint16 slice
+func uint64To16Slice(u64s []uint64) (result []uint16) {
+	var u16s []uint16
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&u16s))
+	hdr.Len = len(u64s) * 4
+	hdr.Cap = hdr.Len
+	hdr.Data = uintptr(unsafe.Pointer(&u64s[0]))
+	return u16s
 }


### PR DESCRIPTION
Optimizes merging bitmaps into superset bitmap. Superset bitmap had to contain originally all the elements that are present in merged bitmaps.
Superset bitmap reuses existing containers to fit calculated data instead creating new ones by allocating more memory.
As elements were present in bitmap before, containers are guaranteed to exist and be large enough to fit all incoming data.