### PR TITLE
feat: serialize small bitmaps as uint64

### DIFF
--- a/bitmap.go
+++ b/bitmap.go
@@ -17,6 +17,7 @@
 package sroar
 
 import (
+	"encoding/binary"
 	"fmt"
 	"math"
 	"sort"
@@ -26,7 +27,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-const mask = uint64(0xFFFFFFFFFFFF0000)
+const (
+	mask                    = uint64(0xFFFFFFFFFFFF0000)
+	serializeAsIntThreshold = 16
+)
 
 type Bitmap struct {
 	data []uint16
@@ -49,6 +53,14 @@ func FromBuffer(data []byte) *Bitmap {
 	if len(data) < 8 {
 		return NewBitmap()
 	}
+	if len(data) < 8*serializeAsIntThreshold {
+		bm := NewBitmapWith(len(data) / 8)
+		for i := 0; i < len(data); i += 8 {
+			val := binary.LittleEndian.Uint64(data[i:])
+			bm.Set(val)
+		}
+		return bm
+	}
 	du := byteTo16SliceUnsafe(data)
 	x := toUint64Slice(du[:4])[indexNodeSize]
 	return &Bitmap{
@@ -65,6 +77,15 @@ func FromBufferWithCopy(src []byte) *Bitmap {
 	if len(src) < 8 {
 		return NewBitmap()
 	}
+	if len(src) <= 8*serializeAsIntThreshold {
+		// For small bitmaps, it's more efficient to convert to array representation.
+		bm := NewBitmapWith(len(src) / 8)
+		for i := 0; i < len(src); i += 8 {
+			val := binary.LittleEndian.Uint64(src[i:])
+			bm.Set(val)
+		}
+		return bm
+	}
 	src16 := byteTo16SliceUnsafe(src)
 	dst16 := make([]uint16, len(src16))
 	copy(dst16, src16)
@@ -76,9 +97,22 @@ func FromBufferWithCopy(src []byte) *Bitmap {
 	}
 }
 
+func uint64SliceToByteSlice(src []uint64, dst []byte) {
+	for i, v := range src {
+		binary.LittleEndian.PutUint64(dst[i*8:], v)
+	}
+}
+
 func (ra *Bitmap) ToBuffer() []byte {
 	if ra.IsEmpty() {
 		return nil
+	}
+	if ra.GetCardinality() <= serializeAsIntThreshold {
+		// For small bitmaps, it's more efficient to convert to array representation.
+		arr := ra.ToArray()
+		dst := make([]byte, len(arr)*8)
+		uint64SliceToByteSlice(arr, dst)
+		return dst
 	}
 	return toByteSlice(ra.data)
 }
@@ -86,6 +120,13 @@ func (ra *Bitmap) ToBuffer() []byte {
 func (ra *Bitmap) ToBufferWithCopy() []byte {
 	if ra.IsEmpty() {
 		return nil
+	}
+	if ra.GetCardinality() <= serializeAsIntThreshold {
+		// For small bitmaps, it's more efficient to convert to array representation.
+		arr := ra.ToArray()
+		dst := make([]byte, len(arr)*8)
+		uint64SliceToByteSlice(arr, dst)
+		return dst
 	}
 	buf := make([]uint16, len(ra.data))
 	copy(buf, ra.data)

--- a/bitmap_opt.go
+++ b/bitmap_opt.go
@@ -689,6 +689,20 @@ func (dst *Bitmap) CompareNumKeys(src *Bitmap) int {
 	}
 }
 
+func (ra *Bitmap) LenSerializedInBytes() int {
+	if ra == nil {
+		return 0
+	}
+	if ra.IsEmpty() {
+		return 0
+	}
+	card := ra.GetCardinality()
+	if card <= serializeAsIntThreshold {
+		return card * 8
+	}
+	return len(ra.data) * 2
+}
+
 func (ra *Bitmap) LenInBytes() int {
 	if ra == nil {
 		return 0

--- a/bitmap_opt_test.go
+++ b/bitmap_opt_test.go
@@ -944,7 +944,7 @@ func TestLenBytes(t *testing.T) {
 		for _, x := range []int{1, 1 + maxCardinality, 1 + maxCardinality*2} {
 			bm.Set(uint64(x))
 
-			require.Equal(t, len(bm.ToBuffer()), bm.LenInBytes())
+			require.Equal(t, len(bm.ToBuffer()), bm.LenSerializedInBytes())
 		}
 	})
 
@@ -952,13 +952,13 @@ func TestLenBytes(t *testing.T) {
 		bm := NewBitmap()
 
 		// real length is greater then 0, though ToBuffer() returns empty slice
-		require.Less(t, 0, bm.LenInBytes())
+		require.Equal(t, 0, bm.LenSerializedInBytes())
 	})
 
 	t.Run("nil bitmap", func(t *testing.T) {
 		var bm *Bitmap
 
-		require.Equal(t, 0, bm.LenInBytes())
+		require.Equal(t, 0, bm.LenSerializedInBytes())
 	})
 }
 


### PR DESCRIPTION
- serialize all bitmap with 16 values or fewer as a list of uint64:
  - (best savings) bitmap with a single large uint64: 352 -> 8 bytes (1*8) 
  - (worse savings) bitmap with 16 small uint64: 176 -> 128 bytes (16*8)