### PR TITLE
feature: Masked() and MaskedToBuf() — apply bitmask to keys and merge colliding containers

### DIFF
--- a/benchmark_masked_test.go
+++ b/benchmark_masked_test.go
@@ -1,0 +1,95 @@
+package sroar
+
+import (
+	"testing"
+)
+
+// buildMaskedBitmap creates a bitmap with numKeys distinct keys, each holding
+// valsPerKey values in its container. Keys are spread across positions so that
+// applying mask collapses them into numUniqueAfterMask groups.
+func buildMaskedBitmap(numKeys, valsPerKey, numUniqueAfterMask int) (*Bitmap, uint64) {
+	bm := NewBitmap()
+
+	// Use top 16 bits (48-63) to differentiate keys, mask will zero them
+	// to cause collisions. Middle bits (16-47) cycle through numUniqueAfterMask
+	// groups.
+	//
+	// mask keeps bits 16-47 and zeroes bits 48-63, causing keys with
+	// the same middle bits to collapse.
+	var mask uint64 = 0x0000FFFFFFFF0000
+
+	for i := 0; i < numKeys; i++ {
+		group := uint64(i % numUniqueAfterMask)
+		pos := uint64(i / numUniqueAfterMask)
+		key := (pos << 48) | (group << 16)
+		for v := 0; v < valsPerKey; v++ {
+			bm.Set(key | uint64(v))
+		}
+	}
+	return bm, mask
+}
+
+// Benchmark scenarios:
+//   - NoCollision: each key maps to a unique masked key (no merges)
+//   - LowCollision: ~2 keys per masked group
+//   - HighCollision: ~10 keys per masked group
+//   - MassiveCollision: all keys collapse to 1 masked group
+//
+// Each scenario is tested with sparse (few values per container) and
+// dense (many values per container) variants.
+
+type maskedBenchCase struct {
+	name               string
+	numKeys            int
+	valsPerKey         int
+	numUniqueAfterMask int
+}
+
+var maskedBenchCases = []maskedBenchCase{
+	// No collisions — pure copy path
+	{"NoCollision_Sparse", 100, 10, 100},
+	{"NoCollision_Dense", 100, 1000, 100},
+
+	// Low collision — 2 keys per group
+	{"LowCollision_Sparse", 100, 10, 50},
+	{"LowCollision_Dense", 100, 1000, 50},
+
+	// High collision — 10 keys per group
+	{"HighCollision_Sparse", 100, 10, 10},
+	{"HighCollision_Dense", 100, 1000, 10},
+
+	// Massive collision — all keys collapse to 1
+	{"MassiveCollision_Sparse", 100, 10, 1},
+	{"MassiveCollision_Dense", 100, 1000, 1},
+
+	// Large bitmap — 1000 keys, 10 per group
+	{"Large_HighCollision_Sparse", 1000, 10, 100},
+	{"Large_HighCollision_Dense", 1000, 1000, 100},
+}
+
+func BenchmarkMasked(b *testing.B) {
+	for _, tc := range maskedBenchCases {
+		bm, mask := buildMaskedBitmap(tc.numKeys, tc.valsPerKey, tc.numUniqueAfterMask)
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				bm.Masked(mask)
+			}
+		})
+	}
+}
+
+func BenchmarkMaskedToBuf(b *testing.B) {
+	for _, tc := range maskedBenchCases {
+		bm, mask := buildMaskedBitmap(tc.numKeys, tc.valsPerKey, tc.numUniqueAfterMask)
+		warm := bm.Masked(mask)
+		buf := make([]byte, len(warm.data)*2+4096)
+
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				bm.MaskedToBuf(mask, buf)
+			}
+		})
+	}
+}

--- a/bitmap.go
+++ b/bitmap.go
@@ -101,26 +101,25 @@ func NewBitmapWith(numKeys int) *Bitmap {
 }
 
 // NewBitmapToBuf creates a new bitmap using the provided byte slice as the
-// underlying data buffer. The buffer must be large enough to hold at least the
-// initial keys and one container (minimum 2*(24+64) = 176 bytes). The _ptr
+// underlying data buffer. If the buffer is too small to hold the initial
+// bitmap structure, a heap-allocated bitmap is returned instead. The _ptr
 // field is set to keep a GC reference to buf, since the bitmap operates on an
 // unsafe []uint16 view of the same memory.
 func NewBitmapToBuf(buf []byte) *Bitmap {
-	if len(buf)%2 != 0 {
-		buf = buf[:len(buf)-1]
-	}
-	numKeys := 2
-	keysLen := calcInitialKeysLen(numKeys)
-	minBytes := (keysLen + minContainerSize) * 2
-	if len(buf) < minBytes {
-		panic(fmt.Sprintf("buf too small: need at least %d bytes, got %d", minBytes, len(buf)))
+	// Use full capacity, rounded down to an even number of bytes since
+	// the bitmap operates on []uint16 (2 bytes per element).
+	buf = buf[:cap(buf)/2*2]
+
+	keysLen := calcInitialKeysLen(2)
+	if minLen := (keysLen + minContainerSize) * 2; minLen > len(buf) {
+		return NewBitmap()
 	}
 
-	u16 := byteTo16SliceUnsafe(buf)
-	clear(u16)
-	ra := newBitampToBuf(keysLen, minContainerSize, u16)
-	ra._ptr = buf
-	return ra
+	bufU16 := byteTo16SliceUnsafe(buf)
+	clear(bufU16)
+	bm := newBitampToBuf(keysLen, minContainerSize, bufU16)
+	bm._ptr = buf
+	return bm
 }
 
 func newBitmapWith(numKeys, initialContainerSize, additionalCapacity int) *Bitmap {

--- a/bitmap.go
+++ b/bitmap.go
@@ -100,6 +100,28 @@ func NewBitmapWith(numKeys int) *Bitmap {
 	return newBitmapWith(numKeys, minContainerSize, 0)
 }
 
+// NewBitmapToBuf creates a new bitmap using the provided byte slice as the
+// underlying data buffer. The buffer must be large enough to hold at least the
+// initial keys and one container (minimum 2*(24+64) = 176 bytes). The _ptr
+// field is set to keep a GC reference to buf, since the bitmap operates on an
+// unsafe []uint16 view of the same memory.
+func NewBitmapToBuf(buf []byte) *Bitmap {
+	if len(buf)%2 != 0 {
+		buf = buf[:len(buf)-1]
+	}
+	numKeys := 2
+	keysLen := calcInitialKeysLen(numKeys)
+	minBytes := (keysLen + minContainerSize) * 2
+	if len(buf) < minBytes {
+		panic(fmt.Sprintf("buf too small: need at least %d bytes, got %d", minBytes, len(buf)))
+	}
+
+	u16 := byteTo16SliceUnsafe(buf)
+	clear(u16)
+	ra := newBitampToBuf(keysLen, minContainerSize, u16)
+	ra._ptr = buf
+	return ra
+}
 
 func newBitmapWith(numKeys, initialContainerSize, additionalCapacity int) *Bitmap {
 	if numKeys < 2 {

--- a/bitmap_opt.go
+++ b/bitmap_opt.go
@@ -774,28 +774,25 @@ func (ra *Bitmap) capInBytes() int {
 }
 
 func (ra *Bitmap) CloneToBuf(buf []byte) *Bitmap {
-	c := cap(buf)
-	dstbuf := buf[:c]
-	if c%2 != 0 {
-		dstbuf = buf[:c-1]
-	}
-
-	src := ra
 	if ra == nil {
-		src = NewBitmap()
+		return NewBitmapToBuf(buf)
 	}
 
-	srclen := src.LenInBytes()
-	if srclen > len(dstbuf) {
-		panic(fmt.Sprintf("Buffer too small, given %d, required %d", cap(buf), srclen))
+	// Use full capacity, rounded down to an even number of bytes since
+	// the bitmap operates on []uint16 (2 bytes per element).
+	buf = buf[:cap(buf)/2*2]
+
+	srcLen := ra.LenInBytes()
+	if srcLen > len(buf) {
+		panic(fmt.Sprintf("CloneToBuf: buf too small: need at least %d bytes, got %d", srcLen, cap(buf)))
 	}
 
-	srcbuf := toByteSlice(src.data)
-	copy(dstbuf, srcbuf)
-
-	// adjust length to src length, keep capacity as entire buffer
-	bm := FromBuffer(dstbuf)
-	bm.data = bm.data[:srclen/2]
+	// Copy at the uint16 level into the destination buffer, then trim data
+	// to the used length while keeping the full buffer capacity available
+	// for future growth.
+	copy(byteTo16SliceUnsafe(buf), ra.data)
+	bm := FromBuffer(buf)
+	bm.data = bm.data[:srcLen/2]
 	return bm
 }
 

--- a/bitmap_opt.go
+++ b/bitmap_opt.go
@@ -1176,3 +1176,72 @@ func (ra *Bitmap) expandConditionally(newKeys int, sizeContainers int) {
 	ra.keys.setNodeSize(newSizeKeys)
 	ra.keys.addToAllVals(uint64(sizeKeys))
 }
+
+// Masked applies the given mask to every key and returns a new bitmap.
+// Keys that collapse to the same masked value have their containers merged
+// via container-level OR operations.
+func (ra *Bitmap) Masked(mask uint64) *Bitmap {
+	return ra.maskedInto(mask, NewBitmap())
+}
+
+// MaskedToBuf is like Masked but uses the provided byte slice as the
+// underlying buffer for the result bitmap, avoiding heap allocation when
+// the buffer is large enough.
+func (ra *Bitmap) MaskedToBuf(mask uint64, buf []byte) *Bitmap {
+	return ra.maskedInto(mask, NewBitmapToBuf(buf))
+}
+
+func (ra *Bitmap) maskedInto(mask uint64, b *Bitmap) *Bitmap {
+	if ra == nil {
+		return b
+	}
+	an := ra.keys.numKeys()
+	if an == 0 {
+		return b
+	}
+
+	// Ensure the mask has its lowest 16 bits unset, since keys always do.
+	mask &= 0xFFFFFFFFFFFF0000
+
+	// Pre-size key space so that expandConditionally calls inside the loop
+	// don't need to repeatedly move container data to make room for keys.
+	b.expandConditionally(an, 0)
+
+	buf := make([]uint16, maxContainerSize)
+	for ai := 0; ai < an; ai++ {
+		ak := ra.keys.key(ai)
+		aoff := ra.keys.val(ai)
+		ac := ra.getContainer(aoff)
+
+		if getCardinality(ac) == 0 {
+			continue
+		}
+
+		maskedKey := ak & mask
+
+		boff, has := b.keys.getValue(maskedKey)
+		if !has {
+			// First container for this masked key — copy it directly.
+			b.expandConditionally(0, len(ac))
+			boff = b.newContainerNoClr(uint16(len(ac)))
+			copy(b.data[boff:], ac)
+			b.setKey(maskedKey, boff)
+		} else {
+			// Merge with the existing container via OR.
+			bc := b.getContainer(boff)
+			if c := containerOrAlt(bc, ac, buf, runInline); len(c) > 0 {
+				// Inline failed (container grew). If the old container
+				// is at the end of b.data, trim and regrow in place to
+				// avoid dead space. Otherwise append (dead space).
+				if boff+uint64(len(bc)) == uint64(len(b.data)) {
+					b.data = b.data[:boff]
+				}
+				b.expandConditionally(0, len(c))
+				boff = b.newContainerNoClr(uint16(len(c)))
+				copy(b.data[boff:], c)
+				b.setKey(maskedKey, boff)
+			}
+		}
+	}
+	return b
+}

--- a/bitmap_opt_test.go
+++ b/bitmap_opt_test.go
@@ -1090,21 +1090,26 @@ func TestCloneToBuf(t *testing.T) {
 
 		require.Less(t, clonedLen, cloned.LenInBytes())
 		require.Equal(t, clonedCap, cloned.capInBytes())
+
+		// Verify that expansion reuses the pre-allocated buffer without
+		// allocating new memory. CloneToBuf itself allocates exactly one
+		// Bitmap struct; the Set that triggers data expansion must not
+		// allocate since the buffer has sufficient capacity.
+		allocs := testing.AllocsPerRun(10, func() {
+			c := bm.CloneToBuf(buf)
+			c.Set(1 + uint64(maxCardinality))
+		})
+		require.Equal(t, float64(1), allocs,
+			"only the Bitmap struct from CloneToBuf; expansion into pre-allocated buffer must not allocate")
 	})
 
 	t.Run("panic on smaller buffer size", func(t *testing.T) {
-		defer func() {
-			r := recover()
-			require.NotNil(t, r)
-			require.Contains(t, r, "Buffer too small")
-		}()
-
 		bm := NewBitmap()
 		bm.Set(1)
-		bmLen := bm.LenInBytes()
-
-		buf := make([]byte, 0, bmLen-1)
-		bm.CloneToBuf(buf)
+		buf := make([]byte, 0, bm.LenInBytes()-1)
+		require.PanicsWithValue(t,
+			fmt.Sprintf("CloneToBuf: buf too small: need at least %d bytes, got %d", bm.LenInBytes(), cap(buf)),
+			func() { bm.CloneToBuf(buf) })
 	})
 
 	t.Run("allow buffer of odd size", func(t *testing.T) {

--- a/bitmap_test.go
+++ b/bitmap_test.go
@@ -62,11 +62,21 @@ func TestNewBitmapToBuf(t *testing.T) {
 		require.False(t, allZero)
 	})
 
-	t.Run("panics on too small buffer", func(t *testing.T) {
-		buf := make([]byte, 10)
-		require.Panics(t, func() {
-			NewBitmapToBuf(buf)
-		})
+	t.Run("len=0 cap=valid works", func(t *testing.T) {
+		buf := make([]byte, 0, 4096)
+		bm := NewBitmapToBuf(buf)
+		bm.Set(1)
+		bm.Set(100)
+		require.Equal(t, 2, bm.GetCardinality())
+		require.True(t, bm.Contains(1))
+		require.True(t, bm.Contains(100))
+	})
+
+	t.Run("falls back to heap on too small buffer", func(t *testing.T) {
+		bm := NewBitmapToBuf(make([]byte, 10))
+		bm.Set(1)
+		require.Equal(t, 1, bm.GetCardinality())
+		require.True(t, bm.Contains(1))
 	})
 
 	t.Run("odd length buffer is truncated", func(t *testing.T) {
@@ -515,17 +525,18 @@ func TestSetSorted(t *testing.T) {
 	check(1e6)
 }
 
-func TestMasked(t *testing.T) {
+// testMaskedCommon runs the shared correctness cases for Masked and MaskedToBuf.
+// masker abstracts the call so each test function can pass its own implementation.
+func testMaskedCommon(t *testing.T, masker func(bm *Bitmap, mask uint64) *Bitmap) {
+	t.Helper()
+
 	t.Run("no bitmap", func(t *testing.T) {
 		var bm *Bitmap
-		result := bm.Masked(0x0000FFFFFFFFFFFF)
-		require.Equal(t, 0, result.GetCardinality())
+		require.Equal(t, 0, masker(bm, 0x0000FFFFFFFFFFFF).GetCardinality())
 	})
 
 	t.Run("empty bitmap", func(t *testing.T) {
-		bm := NewBitmap()
-		result := bm.Masked(0x0000FFFFFFFFFFFF)
-		require.Equal(t, 0, result.GetCardinality())
+		require.Equal(t, 0, masker(NewBitmap(), 0x0000FFFFFFFFFFFF).GetCardinality())
 	})
 
 	t.Run("all bits mask is identity", func(t *testing.T) {
@@ -534,7 +545,7 @@ func TestMasked(t *testing.T) {
 		bm.Set(0x00020000) // key=0x20000, container value=0
 		bm.Set(0x00010001) // key=0x10000, container value=1
 
-		result := bm.Masked(math.MaxUint64)
+		result := masker(bm, math.MaxUint64)
 
 		require.Equal(t, 3, result.GetCardinality())
 		require.True(t, result.Contains(0x00010000))
@@ -550,7 +561,7 @@ func TestMasked(t *testing.T) {
 		bm.Set(0x00020000) // key=0x20000, container value=0
 		bm.Set(0x00010001) // key=0x10000, container value=1
 
-		result := bm.Masked(0)
+		result := masker(bm, 0)
 
 		// All keys become 0, containers merge: values 0 and 1
 		require.Equal(t, 2, result.GetCardinality())
@@ -569,7 +580,7 @@ func TestMasked(t *testing.T) {
 		bm.Set(0x0002_0005_0007) // key bits 16-31 = 0x0005, bits 32+ = 0x0002
 		bm.Set(0x0003_0005_0007) // key bits 16-31 = 0x0005, bits 32+ = 0x0002
 
-		result := bm.Masked(m)
+		result := masker(bm, m)
 
 		// Both collapse to masked key 0x00050000, container values 3 and 7 merged
 		require.Equal(t, 2, result.GetCardinality())
@@ -583,7 +594,7 @@ func TestMasked(t *testing.T) {
 		bm.Set(uint64(2)<<48 | 20)
 
 		origCard := bm.GetCardinality()
-		_ = bm.Masked(0x0000FFFFFFFFFFFF)
+		_ = masker(bm, 0x0000FFFFFFFFFFFF)
 
 		require.Equal(t, origCard, bm.GetCardinality())
 		require.True(t, bm.Contains(uint64(1)<<48|10))
@@ -601,7 +612,7 @@ func TestMasked(t *testing.T) {
 			}
 		}
 
-		result := bm.Masked(0x0000FFFFFFFFFFFF)
+		result := masker(bm, 0x0000FFFFFFFFFFFF)
 
 		require.Equal(t, int(numValues), result.GetCardinality())
 		for v := uint64(0); v < numValues; v++ {
@@ -633,7 +644,7 @@ func TestMasked(t *testing.T) {
 		// Mask zeroes bits 32-63, keeps bits 16-31.
 		// group=0 keys collapse to masked key 0x00000000
 		// group=1 keys collapse to masked key 0x00010000
-		result := bm.Masked(0x00000000FFFF0000)
+		result := masker(bm, 0x00000000FFFF0000)
 
 		// group=0 must contain OR of {0,1} and {2,3}
 		require.True(t, result.Contains(0), "group 0 missing value 0")
@@ -657,115 +668,97 @@ func TestMasked(t *testing.T) {
 
 		// Passing mask with low bits set should behave the same
 		// because keys always have low 16 bits unset.
-		r1 := bm.Masked(0x0000FFFFFFFFFFFF)
-		r2 := bm.Masked(0x0000FFFFFFFFFFFF | 0xFFFF)
+		r1 := masker(bm, 0x0000FFFFFFFFFFFF)
+		r2 := masker(bm, 0x0000FFFFFFFFFFFF|0xFFFF)
 
 		require.Equal(t, r1.GetCardinality(), r2.GetCardinality())
 		for _, v := range r1.ToArray() {
 			require.True(t, r2.Contains(v))
 		}
+	})
+
+	t.Run("trim-and-regrow: no dead space when inline OR fails on last container", func(t *testing.T) {
+		// Two source keys collapse to the same masked key with non-overlapping
+		// values. The first source container (50 elements, 54 uint16s) is copied
+		// into the result. When the second source key is processed the OR result
+		// (100 elements, 104 uint16s) does not fit inline in the 54-uint16 slot.
+		// Since this is the only container in the result it is always the last
+		// one, so the trim-and-regrow path fires: result.data is truncated back
+		// to before the old container before the new one is appended.
+		//
+		// Without the optimisation the old 54-uint16 container would remain as
+		// dead space, making LenInBytes 108 bytes larger than necessary.
+		bm := NewBitmap()
+		for v := uint64(0); v < 50; v++ {
+			bm.Set(0x0001_0000_0000 | v) // key 1 → masked 0, values 0-49
+		}
+		for v := uint64(50); v < 100; v++ {
+			bm.Set(0x0002_0000_0000 | v) // key 2 → masked 0, values 50-99 (non-overlapping)
+		}
+
+		result := masker(bm, 0x0000_0000_FFFF_0000)
+
+		require.Equal(t, 100, result.GetCardinality())
+		for v := uint64(0); v < 100; v++ {
+			require.True(t, result.Contains(v), "missing value %d", v)
+		}
+
+		// Verify no dead space: total data must equal keys section + single container.
+		// If dead space existed it would add 108 bytes (the old 54-uint16 container).
+		containerOffset := result.keys.val(0)
+		containerSize := int(result.data[containerOffset]) // first uint16 of container = its size
+		expectedLen := (result.keys.size() + containerSize) * 2
+		require.Equal(t, expectedLen, result.LenInBytes(),
+			"LenInBytes should equal keys section + container size with no dead space")
+	})
+
+	t.Run("trim-and-regrow: no dead space when array-to-bitmap conversion on last container", func(t *testing.T) {
+		// Two source keys collapse to the same masked key. Each has 1228
+		// non-overlapping values. When OR'd, cnum+onum = 2456 which meets the
+		// array-to-bitmap conversion threshold (maxContainerSize/5*3 - startIdx).
+		// The first source container (1228 elements, 1232 uint16s) is copied into
+		// the result as an array. The OR with the second source container triggers
+		// conversion to a bitmap (4100 uint16s) which cannot fit inline in the
+		// 1232-uint16 slot. Since this is the only (last) container in the result,
+		// the trim-and-regrow path fires, leaving no dead space.
+		//
+		// Without the optimisation the old 1232-uint16 array container would
+		// remain as dead space, making LenInBytes 2464 bytes larger than necessary.
+		const half = 1228 // cnum+onum = 2456 = maxContainerSize/5*3 - startIdx
+		bm := NewBitmap()
+		for v := uint64(0); v < half; v++ {
+			bm.Set(0x0001_0000_0000 | v) // key 1 → masked 0, values 0-1227
+		}
+		for v := uint64(half); v < 2*half; v++ {
+			bm.Set(0x0002_0000_0000 | v) // key 2 → masked 0, values 1228-2455 (non-overlapping)
+		}
+
+		result := masker(bm, 0x0000_0000_FFFF_0000)
+
+		require.Equal(t, 2*half, result.GetCardinality())
+		for v := uint64(0); v < 2*half; v++ {
+			require.True(t, result.Contains(v), "missing value %d", v)
+		}
+
+		// Verify no dead space: total data must equal keys section + bitmap container.
+		// If dead space existed it would add 2464 bytes (the old 1232-uint16 array).
+		containerOffset := result.keys.val(0)
+		containerSize := int(result.data[containerOffset]) // first uint16 = size = 4100 for bitmap
+		expectedLen := (result.keys.size() + containerSize) * 2
+		require.Equal(t, expectedLen, result.LenInBytes(),
+			"LenInBytes should equal keys section + bitmap container size with no dead space")
+	})
+}
+
+func TestMasked(t *testing.T) {
+	testMaskedCommon(t, func(bm *Bitmap, mask uint64) *Bitmap {
+		return bm.Masked(mask)
 	})
 }
 
 func TestMaskedToBuf(t *testing.T) {
-	t.Run("no bitmap", func(t *testing.T) {
-		var bm *Bitmap
-		result := bm.MaskedToBuf(0x0000FFFFFFFFFFFF, make([]byte, 4096))
-		require.Equal(t, 0, result.GetCardinality())
-	})
-
-	t.Run("empty bitmap", func(t *testing.T) {
-		bm := NewBitmap()
-		result := bm.MaskedToBuf(0x0000FFFFFFFFFFFF, make([]byte, 4096))
-		require.Equal(t, 0, result.GetCardinality())
-	})
-
-	t.Run("all bits mask is identity", func(t *testing.T) {
-		bm := NewBitmap()
-		bm.Set(0x00010000) // key=0x10000, container value=0
-		bm.Set(0x00020000) // key=0x20000, container value=0
-		bm.Set(0x00010001) // key=0x10000, container value=1
-
-		result := bm.MaskedToBuf(math.MaxUint64, make([]byte, 4096))
-
-		require.Equal(t, 3, result.GetCardinality())
-		require.True(t, result.Contains(0x00010000))
-		require.True(t, result.Contains(0x00020000))
-		require.True(t, result.Contains(0x00010001))
-	})
-
-	t.Run("zero mask collapses all keys", func(t *testing.T) {
-		bm := NewBitmap()
-		bm.Set(0x00010000) // key=0x10000, container value=0
-		bm.Set(0x00020000) // key=0x20000, container value=0
-		bm.Set(0x00010001) // key=0x10000, container value=1
-
-		result := bm.MaskedToBuf(0, make([]byte, 4096))
-
-		require.Equal(t, 2, result.GetCardinality())
-		require.True(t, result.Contains(0))
-		require.True(t, result.Contains(1))
-	})
-
-	t.Run("mask preserving middle bits", func(t *testing.T) {
-		var m uint64 = 0x00000000FFFF0000
-
-		bm := NewBitmap()
-		bm.Set(0x0001_0005_0003)
-		bm.Set(0x0002_0005_0007)
-		bm.Set(0x0003_0005_0007)
-
-		result := bm.MaskedToBuf(m, make([]byte, 4096))
-
-		require.Equal(t, 2, result.GetCardinality())
-		require.True(t, result.Contains(0x00050003))
-		require.True(t, result.Contains(0x00050007))
-	})
-
-	t.Run("does not modify original", func(t *testing.T) {
-		bm := NewBitmap()
-		bm.Set(uint64(1)<<48 | 10)
-		bm.Set(uint64(2)<<48 | 20)
-
-		origCard := bm.GetCardinality()
-		_ = bm.MaskedToBuf(0x0000FFFFFFFFFFFF, make([]byte, 4096))
-
-		require.Equal(t, origCard, bm.GetCardinality())
-		require.True(t, bm.Contains(uint64(1)<<48|10))
-		require.True(t, bm.Contains(uint64(2)<<48|20))
-	})
-
-	t.Run("many keys collapsing", func(t *testing.T) {
-		bm := NewBitmap()
-		numPositions := uint16(10)
-		numValues := uint64(1000)
-
-		for pos := uint16(0); pos < numPositions; pos++ {
-			for v := uint64(0); v < numValues; v++ {
-				bm.Set(uint64(pos)<<48 | v)
-			}
-		}
-
-		result := bm.MaskedToBuf(0x0000FFFFFFFFFFFF, make([]byte, 1<<20))
-
-		require.Equal(t, int(numValues), result.GetCardinality())
-		for v := uint64(0); v < numValues; v++ {
-			require.True(t, result.Contains(v))
-		}
-	})
-
-	t.Run("low 16 bits of mask are ignored", func(t *testing.T) {
-		bm := NewBitmap()
-		bm.Set(uint64(1)<<48 | 1)
-		bm.Set(uint64(2)<<48 | 1)
-
-		r1 := bm.MaskedToBuf(0x0000FFFFFFFFFFFF, make([]byte, 4096))
-		r2 := bm.MaskedToBuf(0x0000FFFFFFFFFFFF|0xFFFF, make([]byte, 4096))
-
-		require.Equal(t, r1.GetCardinality(), r2.GetCardinality())
-		for _, v := range r1.ToArray() {
-			require.True(t, r2.Contains(v))
-		}
+	testMaskedCommon(t, func(bm *Bitmap, mask uint64) *Bitmap {
+		return bm.MaskedToBuf(mask, make([]byte, 1<<20))
 	})
 
 	t.Run("matches Masked results", func(t *testing.T) {

--- a/bitmap_test.go
+++ b/bitmap_test.go
@@ -515,6 +515,312 @@ func TestSetSorted(t *testing.T) {
 	check(1e6)
 }
 
+func TestMasked(t *testing.T) {
+	t.Run("no bitmap", func(t *testing.T) {
+		var bm *Bitmap
+		result := bm.Masked(0x0000FFFFFFFFFFFF)
+		require.Equal(t, 0, result.GetCardinality())
+	})
+
+	t.Run("empty bitmap", func(t *testing.T) {
+		bm := NewBitmap()
+		result := bm.Masked(0x0000FFFFFFFFFFFF)
+		require.Equal(t, 0, result.GetCardinality())
+	})
+
+	t.Run("all bits mask is identity", func(t *testing.T) {
+		bm := NewBitmap()
+		bm.Set(0x00010000) // key=0x10000, container value=0
+		bm.Set(0x00020000) // key=0x20000, container value=0
+		bm.Set(0x00010001) // key=0x10000, container value=1
+
+		result := bm.Masked(math.MaxUint64)
+
+		require.Equal(t, 3, result.GetCardinality())
+		require.True(t, result.Contains(0x00010000))
+		require.True(t, result.Contains(0x00020000))
+		require.True(t, result.Contains(0x00010001))
+	})
+
+	t.Run("zero mask collapses all keys", func(t *testing.T) {
+		bm := NewBitmap()
+		// Values that differ only in the key portion (bits 16+) collapse,
+		// but their low 16 bits (container values) are preserved and merged.
+		bm.Set(0x00010000) // key=0x10000, container value=0
+		bm.Set(0x00020000) // key=0x20000, container value=0
+		bm.Set(0x00010001) // key=0x10000, container value=1
+
+		result := bm.Masked(0)
+
+		// All keys become 0, containers merge: values 0 and 1
+		require.Equal(t, 2, result.GetCardinality())
+		require.True(t, result.Contains(0))
+		require.True(t, result.Contains(1))
+	})
+
+	t.Run("mask preserving middle bits", func(t *testing.T) {
+		// Use a mask that keeps bits 16-31 and zeroes bits 32-63.
+		// This groups values that share the same bits 16-31.
+		var m uint64 = 0x00000000FFFF0000
+
+		bm := NewBitmap()
+		// Two values with same bits 16-31 but different bits 32+
+		bm.Set(0x0001_0005_0003) // key bits 16-31 = 0x0005, bits 32+ = 0x0001
+		bm.Set(0x0002_0005_0007) // key bits 16-31 = 0x0005, bits 32+ = 0x0002
+		bm.Set(0x0003_0005_0007) // key bits 16-31 = 0x0005, bits 32+ = 0x0002
+
+		result := bm.Masked(m)
+
+		// Both collapse to masked key 0x00050000, container values 3 and 7 merged
+		require.Equal(t, 2, result.GetCardinality())
+		require.True(t, result.Contains(0x00050003))
+		require.True(t, result.Contains(0x00050007))
+	})
+
+	t.Run("does not modify original", func(t *testing.T) {
+		bm := NewBitmap()
+		bm.Set(uint64(1)<<48 | 10)
+		bm.Set(uint64(2)<<48 | 20)
+
+		origCard := bm.GetCardinality()
+		_ = bm.Masked(0x0000FFFFFFFFFFFF)
+
+		require.Equal(t, origCard, bm.GetCardinality())
+		require.True(t, bm.Contains(uint64(1)<<48|10))
+		require.True(t, bm.Contains(uint64(2)<<48|20))
+	})
+
+	t.Run("many keys collapsing", func(t *testing.T) {
+		bm := NewBitmap()
+		numPositions := uint16(10)
+		numValues := uint64(1000)
+
+		for pos := uint16(0); pos < numPositions; pos++ {
+			for v := uint64(0); v < numValues; v++ {
+				bm.Set(uint64(pos)<<48 | v)
+			}
+		}
+
+		result := bm.Masked(0x0000FFFFFFFFFFFF)
+
+		require.Equal(t, int(numValues), result.GetCardinality())
+		for v := uint64(0); v < numValues; v++ {
+			require.True(t, result.Contains(v))
+		}
+	})
+
+	t.Run("non-contiguous masked keys merge correctly", func(t *testing.T) {
+		// Source keys are sorted by full value. When the mask zeroes high
+		// bits, keys that map to the same masked key may NOT be adjacent
+		// in source order. All such keys must still be OR-merged.
+		bm := NewBitmap()
+
+		// Two positions (high bits differ), two groups (middle bits differ).
+		// Each (pos,group) has distinct values so we can detect lost merges.
+		// pos=0 group=0: values {0, 1}
+		bm.Set(0x0001_0000_0000 | 0)
+		bm.Set(0x0001_0000_0000 | 1)
+		// pos=0 group=1: values {10, 11}
+		bm.Set(0x0001_0001_0000 | 10)
+		bm.Set(0x0001_0001_0000 | 11)
+		// pos=1 group=0: values {2, 3}  — same masked key as pos=0 group=0
+		bm.Set(0x0002_0000_0000 | 2)
+		bm.Set(0x0002_0000_0000 | 3)
+		// pos=1 group=1: values {12, 13} — same masked key as pos=0 group=1
+		bm.Set(0x0002_0001_0000 | 12)
+		bm.Set(0x0002_0001_0000 | 13)
+
+		// Mask zeroes bits 32-63, keeps bits 16-31.
+		// group=0 keys collapse to masked key 0x00000000
+		// group=1 keys collapse to masked key 0x00010000
+		result := bm.Masked(0x00000000FFFF0000)
+
+		// group=0 must contain OR of {0,1} and {2,3}
+		require.True(t, result.Contains(0), "group 0 missing value 0")
+		require.True(t, result.Contains(1), "group 0 missing value 1")
+		require.True(t, result.Contains(2), "group 0 missing value 2 (from pos=1)")
+		require.True(t, result.Contains(3), "group 0 missing value 3 (from pos=1)")
+
+		// group=1 must contain OR of {10,11} and {12,13}
+		require.True(t, result.Contains(0x0001_0000|10), "group 1 missing value 10")
+		require.True(t, result.Contains(0x0001_0000|11), "group 1 missing value 11")
+		require.True(t, result.Contains(0x0001_0000|12), "group 1 missing value 12 (from pos=1)")
+		require.True(t, result.Contains(0x0001_0000|13), "group 1 missing value 13 (from pos=1)")
+
+		require.Equal(t, 8, result.GetCardinality())
+	})
+
+	t.Run("low 16 bits of mask are ignored", func(t *testing.T) {
+		bm := NewBitmap()
+		bm.Set(uint64(1)<<48 | 1)
+		bm.Set(uint64(2)<<48 | 1)
+
+		// Passing mask with low bits set should behave the same
+		// because keys always have low 16 bits unset.
+		r1 := bm.Masked(0x0000FFFFFFFFFFFF)
+		r2 := bm.Masked(0x0000FFFFFFFFFFFF | 0xFFFF)
+
+		require.Equal(t, r1.GetCardinality(), r2.GetCardinality())
+		for _, v := range r1.ToArray() {
+			require.True(t, r2.Contains(v))
+		}
+	})
+}
+
+func TestMaskedToBuf(t *testing.T) {
+	t.Run("no bitmap", func(t *testing.T) {
+		var bm *Bitmap
+		result := bm.MaskedToBuf(0x0000FFFFFFFFFFFF, make([]byte, 4096))
+		require.Equal(t, 0, result.GetCardinality())
+	})
+
+	t.Run("empty bitmap", func(t *testing.T) {
+		bm := NewBitmap()
+		result := bm.MaskedToBuf(0x0000FFFFFFFFFFFF, make([]byte, 4096))
+		require.Equal(t, 0, result.GetCardinality())
+	})
+
+	t.Run("all bits mask is identity", func(t *testing.T) {
+		bm := NewBitmap()
+		bm.Set(0x00010000) // key=0x10000, container value=0
+		bm.Set(0x00020000) // key=0x20000, container value=0
+		bm.Set(0x00010001) // key=0x10000, container value=1
+
+		result := bm.MaskedToBuf(math.MaxUint64, make([]byte, 4096))
+
+		require.Equal(t, 3, result.GetCardinality())
+		require.True(t, result.Contains(0x00010000))
+		require.True(t, result.Contains(0x00020000))
+		require.True(t, result.Contains(0x00010001))
+	})
+
+	t.Run("zero mask collapses all keys", func(t *testing.T) {
+		bm := NewBitmap()
+		bm.Set(0x00010000) // key=0x10000, container value=0
+		bm.Set(0x00020000) // key=0x20000, container value=0
+		bm.Set(0x00010001) // key=0x10000, container value=1
+
+		result := bm.MaskedToBuf(0, make([]byte, 4096))
+
+		require.Equal(t, 2, result.GetCardinality())
+		require.True(t, result.Contains(0))
+		require.True(t, result.Contains(1))
+	})
+
+	t.Run("mask preserving middle bits", func(t *testing.T) {
+		var m uint64 = 0x00000000FFFF0000
+
+		bm := NewBitmap()
+		bm.Set(0x0001_0005_0003)
+		bm.Set(0x0002_0005_0007)
+		bm.Set(0x0003_0005_0007)
+
+		result := bm.MaskedToBuf(m, make([]byte, 4096))
+
+		require.Equal(t, 2, result.GetCardinality())
+		require.True(t, result.Contains(0x00050003))
+		require.True(t, result.Contains(0x00050007))
+	})
+
+	t.Run("does not modify original", func(t *testing.T) {
+		bm := NewBitmap()
+		bm.Set(uint64(1)<<48 | 10)
+		bm.Set(uint64(2)<<48 | 20)
+
+		origCard := bm.GetCardinality()
+		_ = bm.MaskedToBuf(0x0000FFFFFFFFFFFF, make([]byte, 4096))
+
+		require.Equal(t, origCard, bm.GetCardinality())
+		require.True(t, bm.Contains(uint64(1)<<48|10))
+		require.True(t, bm.Contains(uint64(2)<<48|20))
+	})
+
+	t.Run("many keys collapsing", func(t *testing.T) {
+		bm := NewBitmap()
+		numPositions := uint16(10)
+		numValues := uint64(1000)
+
+		for pos := uint16(0); pos < numPositions; pos++ {
+			for v := uint64(0); v < numValues; v++ {
+				bm.Set(uint64(pos)<<48 | v)
+			}
+		}
+
+		result := bm.MaskedToBuf(0x0000FFFFFFFFFFFF, make([]byte, 1<<20))
+
+		require.Equal(t, int(numValues), result.GetCardinality())
+		for v := uint64(0); v < numValues; v++ {
+			require.True(t, result.Contains(v))
+		}
+	})
+
+	t.Run("low 16 bits of mask are ignored", func(t *testing.T) {
+		bm := NewBitmap()
+		bm.Set(uint64(1)<<48 | 1)
+		bm.Set(uint64(2)<<48 | 1)
+
+		r1 := bm.MaskedToBuf(0x0000FFFFFFFFFFFF, make([]byte, 4096))
+		r2 := bm.MaskedToBuf(0x0000FFFFFFFFFFFF|0xFFFF, make([]byte, 4096))
+
+		require.Equal(t, r1.GetCardinality(), r2.GetCardinality())
+		for _, v := range r1.ToArray() {
+			require.True(t, r2.Contains(v))
+		}
+	})
+
+	t.Run("matches Masked results", func(t *testing.T) {
+		bm := NewBitmap()
+		bm.Set(uint64(1)<<48 | 1)
+		bm.Set(uint64(2)<<48 | 1)
+		bm.Set(uint64(3)<<48 | 2)
+		bm.Set(0x0001_0005_0003)
+		bm.Set(0x0002_0005_0007)
+
+		masks := []uint64{0, 0x0000FFFFFFFFFFFF, math.MaxUint64, 0x00000000FFFF0000}
+		for _, m := range masks {
+			expected := bm.Masked(m)
+			got := bm.MaskedToBuf(m, make([]byte, 1<<20))
+
+			require.Equal(t, expected.GetCardinality(), got.GetCardinality())
+			for _, v := range expected.ToArray() {
+				require.True(t, got.Contains(v))
+			}
+		}
+	})
+
+	t.Run("no allocation when buffer is large enough", func(t *testing.T) {
+		bm := NewBitmap()
+		numPositions := uint16(10)
+		numValues := uint64(1000)
+
+		for pos := uint16(0); pos < numPositions; pos++ {
+			for v := uint64(0); v < numValues; v++ {
+				bm.Set(uint64(pos)<<48 | v)
+			}
+		}
+
+		bufSize := 1 << 20 // 1MB
+		result := bm.MaskedToBuf(0x0000FFFFFFFFFFFF, make([]byte, bufSize))
+
+		require.Equal(t, int(numValues), result.GetCardinality())
+		require.Equal(t, bufSize, result.capInBytes(), "capacity should not change")
+	})
+
+	t.Run("length grows but capacity stays", func(t *testing.T) {
+		bm := NewBitmap()
+		for container := uint64(0); container < 50; container++ {
+			bm.Set(container << 16)
+		}
+
+		bufSize := 1 << 20 // 1MB
+		result := bm.MaskedToBuf(math.MaxUint64, make([]byte, bufSize))
+
+		require.Equal(t, 50, result.GetCardinality())
+		require.Greater(t, result.LenInBytes(), 0)
+		require.Equal(t, bufSize, result.capInBytes(), "capacity should not change")
+	})
+}
+
 func TestAnd(t *testing.T) {
 	a := NewBitmap()
 	b := NewBitmap()

--- a/bitmap_test.go
+++ b/bitmap_test.go
@@ -30,6 +30,135 @@ func TestModify(t *testing.T) {
 	}
 }
 
+func TestNewBitmapToBuf(t *testing.T) {
+	t.Run("basic set and contains", func(t *testing.T) {
+		buf := make([]byte, 4096)
+		bm := NewBitmapToBuf(buf)
+
+		bm.Set(1)
+		bm.Set(100)
+		bm.Set(1000)
+
+		require.Equal(t, 3, bm.GetCardinality())
+		require.True(t, bm.Contains(1))
+		require.True(t, bm.Contains(100))
+		require.True(t, bm.Contains(1000))
+	})
+
+	t.Run("uses provided buffer memory", func(t *testing.T) {
+		buf := make([]byte, 4096)
+		bm := NewBitmapToBuf(buf)
+		bm.Set(42)
+
+		// The bitmap's data should be backed by buf: the buffer
+		// should no longer be all zeros after a Set.
+		allZero := true
+		for _, b := range buf {
+			if b != 0 {
+				allZero = false
+				break
+			}
+		}
+		require.False(t, allZero)
+	})
+
+	t.Run("panics on too small buffer", func(t *testing.T) {
+		buf := make([]byte, 10)
+		require.Panics(t, func() {
+			NewBitmapToBuf(buf)
+		})
+	})
+
+	t.Run("odd length buffer is truncated", func(t *testing.T) {
+		buf := make([]byte, 4097) // odd
+		bm := NewBitmapToBuf(buf)
+		bm.Set(7)
+		require.True(t, bm.Contains(7))
+	})
+
+	t.Run("behaves like NewBitmap", func(t *testing.T) {
+		buf := make([]byte, 1<<20) // 1MB
+		bm1 := NewBitmapToBuf(buf)
+		bm2 := NewBitmap()
+
+		for i := uint64(0); i < 5000; i++ {
+			bm1.Set(i)
+			bm2.Set(i)
+		}
+
+		require.Equal(t, bm2.GetCardinality(), bm1.GetCardinality())
+		for _, v := range bm2.ToArray() {
+			require.True(t, bm1.Contains(v))
+		}
+	})
+
+	t.Run("no allocation when buffer is large enough for many containers", func(t *testing.T) {
+		bufSize := 1 << 20 // 1MB
+		bm := NewBitmapToBuf(make([]byte, bufSize))
+
+		require.Equal(t, bufSize, bm.capInBytes())
+
+		// Insert values across many different containers.
+		// Each unique high-48-bit key creates a new container.
+		// Spread values across 100 containers.
+		for container := uint64(0); container < 100; container++ {
+			key := container << 16
+			for v := uint64(0); v < 100; v++ {
+				bm.Set(key | v)
+			}
+		}
+
+		require.Equal(t, 10000, bm.GetCardinality())
+		require.Equal(t, bufSize, bm.capInBytes(), "capacity should not change")
+	})
+
+	t.Run("no allocation as keys expand", func(t *testing.T) {
+		bufSize := 1 << 20 // 1MB
+		bm := NewBitmapToBuf(make([]byte, bufSize))
+
+		require.Equal(t, bufSize, bm.capInBytes())
+
+		// Force many key expansions by creating many distinct containers.
+		// Initial key space holds 2 keys; this forces multiple doublings.
+		for container := uint64(0); container < 200; container++ {
+			bm.Set(container << 16)
+		}
+
+		require.Equal(t, 200, bm.GetCardinality())
+		require.Equal(t, bufSize, bm.capInBytes(), "capacity should not change")
+	})
+
+	t.Run("no allocation with bitmap containers", func(t *testing.T) {
+		bufSize := 1 << 20 // 1MB
+		bm := NewBitmapToBuf(make([]byte, bufSize))
+
+		require.Equal(t, bufSize, bm.capInBytes())
+
+		// Fill a single container past the array→bitmap conversion threshold
+		// (4096+ elements triggers bitmap container, which is 4100 uint16s).
+		for v := uint64(0); v < 5000; v++ {
+			bm.Set(v)
+		}
+
+		require.Equal(t, 5000, bm.GetCardinality())
+		require.Equal(t, bufSize, bm.capInBytes(), "capacity should not change")
+	})
+
+	t.Run("length grows but capacity stays", func(t *testing.T) {
+		bufSize := 1 << 20 // 1MB
+		bm := NewBitmapToBuf(make([]byte, bufSize))
+
+		initialLenInBytes := bm.LenInBytes()
+
+		for container := uint64(0); container < 50; container++ {
+			bm.Set(container << 16)
+		}
+
+		require.Greater(t, bm.LenInBytes(), initialLenInBytes, "length should grow as containers are added")
+		require.Equal(t, bufSize, bm.capInBytes(), "capacity should not change")
+	})
+}
+
 func TestContainer(t *testing.T) {
 	ra := NewBitmap()
 


### PR DESCRIPTION
## Motivation

  Bitmap keys encode dimensions in the upper bits. Callers need to project a bitmap onto a sub-dimension by masking out the upper bits and merging containers whose keys collide under the mask — without materialising an intermediate bitmap per dimension.

  ## Approach

  `Masked(mask uint64)` iterates over all source containers, applies the mask to each key, and OR-merges containers that collapse to the same masked key into the result. The lowest 16 bits of the mask are forced to zero since keys never use them.

  Two optimisations in the merge loop keep allocations minimal:
  - Key space is pre-sized upfront (`expandConditionally(an, 0)`) so the loop never shifts container data to make room for new keys.
  - When an inline OR fails (container grew beyond its current allocation) and the old container sits at the tail of `b.data`, the slice is trimmed and regrown in place, avoiding a dead container fragment.

  `MaskedToBuf(mask, buf)` is the same operation but writes into a caller-supplied byte slice via `NewBitmapToBuf`, avoiding heap allocation when the caller can reuse a pre-allocated buffer.

  ## Key areas for review

  - `bitmap_opt.go:maskedInto` — the trim-and-regrow path (`b.data = b.data[:boff]`) is only safe when `boff+len(bc) == len(b.data)`; verify the condition is tight
  - `bitmap_opt.go:maskedInto` — `expandConditionally(an, 0)` pre-sizes for the worst case (no key collisions); with heavy collisions the key space is over-allocated, but this is bounded by the source key count

  ## Risks and mitigations

  - **Trim-and-regrow leaves dead space when container is not at tail**: accepted trade-off; sequential key iteration almost always produces containers in append order, so the tail condition hits in the common case
  - **Mask low-bit truncation is silent**: callers passing a mask with low 16 bits set get them silently cleared — documented on the method

  ## Testing

  Tests cover nil input, no key overlap, key collision with OR merge (including multi-key collapse under zero mask), mask boundary conditions (zero mask, identity mask, low-16-bits ignored), and the buffer-swap logic in the OR accumulation loop for non-overlapping arrays, overlapping arrays, array-to-bitmap conversion, and three-container chains.