### PR TITLE
feature: dim-aware bitmap — store and query 80-bit values (64-bit + 16-bit dimension)

### DIFF
--- a/bitmap.go
+++ b/bitmap.go
@@ -432,7 +432,14 @@ func (ra *Bitmap) IsEmpty() bool {
 }
 
 func (ra *Bitmap) Set(x uint64) bool {
-	key := x & mask
+	return ra.SetDim(x, 0)
+}
+
+// SetDim adds x to the bitmap under the given dimension. The key is formed
+// from the upper 48 bits of x combined with dim in the lowest 16 bits,
+// enabling storage of 80-bit values (64-bit x + 16-bit dim).
+func (ra *Bitmap) SetDim(x uint64, dim uint16) bool {
+	key := x&mask | uint64(dim)
 	offset, has := ra.keys.getValue(key)
 	if !has {
 		ra.expandConditionally(1, minContainerSize)
@@ -461,6 +468,12 @@ func (ra *Bitmap) Set(x uint64) bool {
 }
 
 func FromSortedList(vals []uint64) *Bitmap {
+	return FromSortedListDim(vals, 0)
+}
+
+// FromSortedListDim creates a bitmap from a sorted list of values, all
+// stored under the given dimension.
+func FromSortedListDim(vals []uint64, dim uint16) *Bitmap {
 	var arr []uint16
 	var hi, lastHi, off uint64
 
@@ -507,8 +520,7 @@ func FromSortedList(vals []uint64) *Bitmap {
 				bitmap(c).add(v)
 			}
 		}
-		ra.setKey(key, off)
-		return
+		ra.setKey(key+uint64(dim), off)
 	}
 
 	lastHi = 0
@@ -560,10 +572,15 @@ func (ra *Bitmap) Select(x uint64) (uint64, error) {
 }
 
 func (ra *Bitmap) Contains(x uint64) bool {
+	return ra.ContainsDim(x, 0)
+}
+
+// ContainsDim reports whether x is present in the bitmap under the given dimension.
+func (ra *Bitmap) ContainsDim(x uint64, dim uint16) bool {
 	if ra == nil {
 		return false
 	}
-	key := x & mask
+	key := x&mask | uint64(dim)
 	offset, has := ra.keys.getValue(key)
 	if !has {
 		return false
@@ -583,10 +600,15 @@ func (ra *Bitmap) Contains(x uint64) bool {
 }
 
 func (ra *Bitmap) Remove(x uint64) bool {
+	return ra.RemoveDim(x, 0)
+}
+
+// RemoveDim removes x from the bitmap under the given dimension.
+func (ra *Bitmap) RemoveDim(x uint64, dim uint16) bool {
 	if ra == nil {
 		return false
 	}
-	key := x & mask
+	key := x&mask | uint64(dim)
 	offset, has := ra.keys.getValue(key)
 	if !has {
 		return false
@@ -605,6 +627,11 @@ func (ra *Bitmap) Remove(x uint64) bool {
 
 // Remove range removes [lo, hi) from the bitmap.
 func (ra *Bitmap) RemoveRange(lo, hi uint64) {
+	ra.RemoveRangeDim(lo, hi, 0)
+}
+
+// RemoveRangeDim removes all values in [lo, hi) from the bitmap under the given dimension.
+func (ra *Bitmap) RemoveRangeDim(lo, hi uint64, dim uint16) {
 	if lo > hi {
 		panic("lo should not be more than hi")
 	}
@@ -612,8 +639,8 @@ func (ra *Bitmap) RemoveRange(lo, hi uint64) {
 		return
 	}
 
-	k1 := lo & mask
-	k2 := hi & mask
+	k1 := lo&mask | uint64(dim)
+	k2 := hi&mask | uint64(dim)
 
 	defer ra.Cleanup()
 
@@ -636,6 +663,9 @@ func (ra *Bitmap) RemoveRange(lo, hi uint64) {
 
 	for i := st; i < n; i++ {
 		key := ra.keys.key(i)
+		if uint16(key) != dim {
+			continue
+		}
 		if key >= k2 {
 			break
 		}
@@ -687,12 +717,21 @@ func (ra *Bitmap) ZeroOut() {
 }
 
 func (ra *Bitmap) GetCardinality() int {
+	return ra.GetCardinalityDim(0)
+}
+
+// GetCardinalityDim returns the number of values stored under the given dimension.
+func (ra *Bitmap) GetCardinalityDim(dim uint16) int {
 	if ra == nil {
 		return 0
 	}
 	N := ra.keys.numKeys()
 	var sz int
 	for i := 0; i < N; i++ {
+		key := ra.keys.key(i)
+		if uint16(key) != dim {
+			continue
+		}
 		offset := ra.keys.val(i)
 		// Pass ra.data[offset:] directly to skip getContainer — getCardinality
 		// only reads indices 2 and 3, so no bounded slice is needed.
@@ -702,16 +741,25 @@ func (ra *Bitmap) GetCardinality() int {
 }
 
 func (ra *Bitmap) ToArray() []uint64 {
+	return ra.ToArrayDim(0)
+}
+
+// ToArrayDim returns all values stored under the given dimension as a sorted slice.
+func (ra *Bitmap) ToArrayDim(dim uint16) []uint64 {
 	if ra == nil {
 		return nil
 	}
-	res := make([]uint64, 0, ra.GetCardinality())
+	res := make([]uint64, 0, ra.GetCardinalityDim(dim))
 	N := ra.keys.numKeys()
 	for i := 0; i < N; i++ {
 		key := ra.keys.key(i)
+		if uint16(key) != dim {
+			continue
+		}
 		off := ra.keys.val(i)
 		c := ra.getContainer(off)
 
+		key = key & mask
 		switch c[indexType] {
 		case typeArray:
 			a := array(c)
@@ -1384,4 +1432,47 @@ func (bm *Bitmap) Split(externalSize func(start, end uint64) uint64, maxSz uint6
 	}
 
 	return splits
+}
+
+// MergeDims merges containers across all dimensions, returning a new bitmap
+// where keys that share the same upper 48 bits (differing only in the dim
+// bits 0-15) have their containers OR-merged.
+func (ra *Bitmap) MergeDims() *Bitmap {
+	return ra.maskedInto(0xFFFFFFFFFFFF0000, NewBitmap())
+}
+
+// ToMapDims returns a map from each 64-bit value to the list of dimensions
+// in which it is stored.
+func (ra *Bitmap) ToMapDims() map[uint64][]uint16 {
+	if ra == nil {
+		return nil
+	}
+
+	res := map[uint64][]uint16{}
+	N := ra.keys.numKeys()
+	for i := 0; i < N; i++ {
+		k := ra.keys.key(i)
+		off := ra.keys.val(i)
+		c := ra.getContainer(off)
+		if getCardinality(c) == 0 {
+			continue
+		}
+
+		key := k & mask
+		dim := uint16(k)
+		var all []uint16
+
+		switch c[indexType] {
+		case typeArray:
+			all = array(c).all()
+		case typeBitmap:
+			all = bitmap(c).all()
+		}
+
+		for _, val := range all {
+			x := key | uint64(val)
+			res[x] = append(res[x], dim)
+		}
+	}
+	return res
 }

--- a/bitmap_opt.go
+++ b/bitmap_opt.go
@@ -1179,14 +1179,16 @@ func (ra *Bitmap) expandConditionally(newKeys int, sizeContainers int) {
 
 // Masked applies the given mask to every key and returns a new bitmap.
 // Keys that collapse to the same masked value have their containers merged
-// via container-level OR operations.
+// via container-level OR operations. The lowest 16 bits of keys (used for
+// dimensions in Dim-aware bitmaps) are always zeroed, collapsing all
+// dimensions implicitly.
 func (ra *Bitmap) Masked(mask uint64) *Bitmap {
 	return ra.maskedInto(mask, NewBitmap())
 }
 
 // MaskedToBuf is like Masked but uses the provided byte slice as the
 // underlying buffer for the result bitmap, avoiding heap allocation when
-// the buffer is large enough.
+// the buffer is large enough. The lowest 16 bits of keys are always zeroed.
 func (ra *Bitmap) MaskedToBuf(mask uint64, buf []byte) *Bitmap {
 	return ra.maskedInto(mask, NewBitmapToBuf(buf))
 }
@@ -1380,9 +1382,12 @@ func maskedEntriesFor(entries []maskedEntry, key uint64, from int) ([]maskedEntr
 // AndMasked is equivalent to ra.And(b.Masked(mask)) but avoids allocating
 // an intermediate masked bitmap. b is not modified.
 //
-// For each key k in ra, AndMasked finds all keys k' in b where k'&mask == k,
-// ORs their containers together, then ANDs the result into ra's container at k.
-// If no key in b maps to k under the mask, ra's container at k is zeroed out.
+// For each key k in ra with dim=0 (low 16 bits == 0), AndMasked finds all
+// keys k' in b where k'&mask == k, ORs their containers together, then ANDs
+// the result into ra's container at k. If no key in b maps to k under the
+// mask, ra's container at k is zeroed out.
+// Containers in ra whose key has a non-zero dimension (low 16 bits != 0) are
+// left untouched — they are neither ANDed nor zeroed.
 // The lowest 16 bits of the mask are always ignored.
 func (ra *Bitmap) AndMasked(b *Bitmap, mask uint64) *Bitmap {
 	if b.IsEmpty() {
@@ -1397,6 +1402,8 @@ func (ra *Bitmap) AndMasked(b *Bitmap, mask uint64) *Bitmap {
 }
 
 // AndMaskedConc is like AndMasked but processes ra's containers concurrently.
+// Containers in ra with a non-zero dimension (low 16 bits != 0) are left
+// untouched — they are neither ANDed nor zeroed. See AndMasked for details.
 // Concurrency is calculated based on number of internal containers in ra, so
 // that each goroutine handles at least [minContainersPerRoutine] containers.
 // maxConcurrency limits concurrency calculated internally.
@@ -1442,6 +1449,12 @@ func andMaskedContainersInRange(ra, b *Bitmap, entries []maskedEntry, ai, aj int
 
 	for ; ai < aj; ai++ {
 		ak := ra.keys.key(ai)
+		if uint16(ak) != 0 {
+			// Non-zero dimension — leave container untouched and do not
+			// advance from, preserving the monotonic scan invariant for
+			// the dim=0 keys that follow.
+			continue
+		}
 		ac := ra.getContainer(ra.keys.val(ai))
 
 		var group []maskedEntry

--- a/bitmap_opt.go
+++ b/bitmap_opt.go
@@ -1245,3 +1245,86 @@ func (ra *Bitmap) maskedInto(mask uint64, b *Bitmap) *Bitmap {
 	}
 	return b
 }
+
+// MaskedAnd returns a new bitmap containing the AND of a and b, with mask
+// applied to all keys. Keys that become equal after masking have their
+// containers merged via OR. This is equivalent to Masked(And(a, b), mask)
+// but allocates only one bitmap instead of two. Neither a nor b is modified.
+// The lowest 16 bits of keys are always zeroed.
+func MaskedAnd(a, b *Bitmap, mask uint64) *Bitmap {
+	return maskedAndInto(a, b, mask, NewBitmap())
+}
+
+// MaskedAndToBuf is like MaskedAnd but uses the provided byte slice as the
+// underlying buffer for the result bitmap, avoiding heap allocation when
+// the buffer is large enough. The lowest 16 bits of keys are always zeroed.
+func MaskedAndToBuf(a, b *Bitmap, mask uint64, buf []byte) *Bitmap {
+	return maskedAndInto(a, b, mask, NewBitmapToBuf(buf))
+}
+
+func maskedAndInto(a, b *Bitmap, mask uint64, res *Bitmap) *Bitmap {
+	if a.IsEmpty() || b.IsEmpty() {
+		return res
+	}
+
+	mask &= 0xFFFFFFFFFFFF0000
+
+	ai, an := 0, a.keys.numKeys()
+	bi, bn := 0, b.keys.numKeys()
+
+	// AND can produce at most min(an, bn) distinct keys before masking.
+	minKeys := min(an, bn)
+	res.expandConditionally(minKeys, 0)
+
+	// andBuf holds the AND result for one container pair.
+	// orBuf is the scratch for merging into res when masked keys collide.
+	// They must be separate since andBuf is the OR source.
+	andBuf := make([]uint16, maxContainerSize)
+	orBuf := make([]uint16, maxContainerSize)
+
+	for ai < an && bi < bn {
+		ak := a.keys.key(ai)
+		bk := b.keys.key(bi)
+
+		if ak == bk {
+			ac := a.getContainer(a.keys.val(ai))
+			bc := b.getContainer(b.keys.val(bi))
+
+			c := containerAndAlt(ac, bc, andBuf, 0)
+			if len(c) > 0 && getCardinality(c) > 0 {
+				maskedKey := ak & mask
+
+				roff, has := res.keys.getValue(maskedKey)
+				if !has {
+					// First container for this masked key — copy it directly.
+					res.expandConditionally(0, len(c))
+					roff = res.newContainerNoClr(uint16(len(c)))
+					copy(res.data[roff:], c)
+					res.setKey(maskedKey, roff)
+				} else {
+					// Merge with the existing container via OR.
+					rc := res.getContainer(roff)
+					if out := containerOrAlt(rc, c, orBuf, runInline); len(out) > 0 {
+						// Inline failed (container grew). If the old container
+						// is at the end of res.data, trim and regrow in place to
+						// avoid dead space. Otherwise append (dead space).
+						if roff+uint64(len(rc)) == uint64(len(res.data)) {
+							res.data = res.data[:roff]
+						}
+						res.expandConditionally(0, len(out))
+						roff = res.newContainerNoClr(uint16(len(out)))
+						copy(res.data[roff:], out)
+						res.setKey(maskedKey, roff)
+					}
+				}
+			}
+			ai++
+			bi++
+		} else if ak < bk {
+			ai++
+		} else {
+			bi++
+		}
+	}
+	return res
+}

--- a/bitmap_opt.go
+++ b/bitmap_opt.go
@@ -1328,3 +1328,154 @@ func maskedAndInto(a, b *Bitmap, mask uint64, res *Bitmap) *Bitmap {
 	}
 	return res
 }
+
+// maskedEntry pairs a bitmap container's offset with the masked value of its key.
+type maskedEntry struct{ maskedKey, offset uint64 }
+
+// buildMaskedEntries returns a sorted slice of maskedEntry for bm, with each
+// key masked by mask. The result is sorted by maskedKey for binary search.
+func buildMaskedEntries(bm *Bitmap, mask uint64) []maskedEntry {
+	n := bm.keys.numKeys()
+	entries := make([]maskedEntry, n)
+	for i := 0; i < n; i++ {
+		entries[i] = maskedEntry{
+			maskedKey: bm.keys.key(i) & mask,
+			offset:    bm.keys.val(i),
+		}
+	}
+	slices.SortFunc(entries, func(a, b maskedEntry) int {
+		if a.maskedKey < b.maskedKey {
+			return -1
+		}
+		if a.maskedKey > b.maskedKey {
+			return 1
+		}
+		return 0
+	})
+	return entries
+}
+
+// maskedEntriesFor returns the subslice of entries whose maskedKey equals key
+// and the position to pass as from on the next call, or nil if no match exists.
+// from is a hint: the caller passes back the value returned by the previous
+// call, allowing a linear scan across a sorted sequence of keys instead of a
+// binary search on every call.
+// entries must be sorted by maskedKey, and successive calls must use
+// non-decreasing key values.
+func maskedEntriesFor(entries []maskedEntry, key uint64, from int) ([]maskedEntry, int) {
+	for from < len(entries) && entries[from].maskedKey < key {
+		from++
+	}
+	if from >= len(entries) || entries[from].maskedKey != key {
+		return nil, from
+	}
+	lo := from
+	hi := lo + 1
+	for hi < len(entries) && entries[hi].maskedKey == key {
+		hi++
+	}
+	return entries[lo:hi], hi
+}
+
+// AndMasked is equivalent to ra.And(b.Masked(mask)) but avoids allocating
+// an intermediate masked bitmap. b is not modified.
+//
+// For each key k in ra, AndMasked finds all keys k' in b where k'&mask == k,
+// ORs their containers together, then ANDs the result into ra's container at k.
+// If no key in b maps to k under the mask, ra's container at k is zeroed out.
+// The lowest 16 bits of the mask are always ignored.
+func (ra *Bitmap) AndMasked(b *Bitmap, mask uint64) *Bitmap {
+	if b.IsEmpty() {
+		ra.ZeroOut()
+		return ra
+	}
+
+	mask &= 0xFFFFFFFFFFFF0000
+	entries := buildMaskedEntries(b, mask)
+	andMaskedContainersInRange(ra, b, entries, 0, ra.keys.numKeys())
+	return ra
+}
+
+// AndMaskedConc is like AndMasked but processes ra's containers concurrently.
+// Concurrency is calculated based on number of internal containers in ra, so
+// that each goroutine handles at least [minContainersPerRoutine] containers.
+// maxConcurrency limits concurrency calculated internally.
+// If maxConcurrency <= 0, then calculated concurrency is not limited.
+func (ra *Bitmap) AndMaskedConc(b *Bitmap, mask uint64, maxConcurrency int) *Bitmap {
+	if b.IsEmpty() {
+		ra.ZeroOut()
+		return ra
+	}
+
+	mask &= 0xFFFFFFFFFFFF0000
+
+	// Build entries once; goroutines only read from it.
+	entries := buildMaskedEntries(b, mask)
+
+	an := ra.keys.numKeys()
+	concurrency := calcConcurrency(an, minContainersPerRoutine, maxConcurrency)
+	callback := func(ai, aj, _ int) { andMaskedContainersInRange(ra, b, entries, ai, aj) }
+	concurrentlyInRanges(an, concurrency, callback)
+	return ra
+}
+
+func andMaskedContainersInRange(ra, b *Bitmap, entries []maskedEntry, ai, aj int) {
+	// orBuf holds the accumulated OR result across the group.
+	// fallbackBuf is needed only when inline OR fails (array+array that must
+	// convert to bitmap): the result lands in fallbackBuf, which is then swapped
+	// with orBuf so subsequent iterations continue to use orBuf as the target.
+	orBuf := make([]uint16, maxContainerSize)
+	fallbackBuf := make([]uint16, maxContainerSize)
+
+	// Binary search to find the starting position in entries for this range.
+	// The two-pointer optimisation used in the sequential path is not applicable
+	// here since each goroutine starts at an arbitrary key.
+	from, _ := slices.BinarySearchFunc(entries, ra.keys.key(ai), func(e maskedEntry, k uint64) int {
+		if e.maskedKey < k {
+			return -1
+		}
+		if e.maskedKey > k {
+			return 1
+		}
+		return 0
+	})
+
+	for ; ai < aj; ai++ {
+		ak := ra.keys.key(ai)
+		ac := ra.getContainer(ra.keys.val(ai))
+
+		var group []maskedEntry
+		group, from = maskedEntriesFor(entries, ak, from)
+		if group == nil {
+			// No b key maps to ak under the mask — zero out ra's container.
+			zeroOutContainer(ac)
+			continue
+		}
+
+		// Build the OR of all b containers in the group.
+		var orResult []uint16
+		if len(group) == 1 {
+			// Single container — use directly, no OR needed.
+			orResult = b.getContainer(group[0].offset)
+		} else {
+			// Copy the first container into orBuf so we can OR into it in place.
+			copy(orBuf, b.getContainer(group[0].offset))
+			orResult = orBuf
+
+			for i := 1; i < len(group); i++ {
+				if c := containerOrAlt(orResult, b.getContainer(group[i].offset), fallbackBuf, runInline); len(c) > 0 {
+					// Inline failed (array→bitmap conversion): result is in fallbackBuf.
+					// Swap so orBuf always holds the current result.
+					orBuf, fallbackBuf = fallbackBuf, orBuf
+					orResult = c
+				}
+			}
+		}
+
+		// AND ra's container with the OR result, in place. AND can only
+		// shrink a container so inline always succeeds.
+		if c := containerAndAlt(ac, orResult, nil, runInline); len(c) > 0 {
+			panic("new container not expected in AndMasked inline mode")
+		}
+	}
+}

--- a/bitmap_opt_test.go
+++ b/bitmap_opt_test.go
@@ -2879,3 +2879,441 @@ func TestMaskedAndToBuf(t *testing.T) {
 		require.Equal(t, bufSize, result.capInBytes(), "capacity should not change")
 	})
 }
+
+func TestAndMasked(t *testing.T) {
+	t.Run("empty b zeroes ra", func(t *testing.T) {
+		ra := NewBitmap()
+		ra.Set(1)
+		ra.Set(2)
+		ra.AndMasked(NewBitmap(), math.MaxUint64)
+		require.Equal(t, 0, ra.GetCardinality())
+	})
+
+	t.Run("nil b zeroes ra", func(t *testing.T) {
+		ra := NewBitmap()
+		ra.Set(1)
+		var b *Bitmap
+		ra.AndMasked(b, math.MaxUint64)
+		require.Equal(t, 0, ra.GetCardinality())
+	})
+
+	t.Run("identity mask matches ra.And(b)", func(t *testing.T) {
+		for _, mask := range []uint64{math.MaxUint64, math.MaxUint64 | 0xFFFF} {
+			ra := NewBitmap()
+			b := NewBitmap()
+			for i := uint64(0); i < 200; i++ {
+				ra.Set(i)
+				if i%2 == 0 {
+					b.Set(i)
+				}
+			}
+
+			expected := ra.Clone()
+			expected.And(b)
+
+			ra.AndMasked(b, mask)
+
+			require.Equal(t, expected.GetCardinality(), ra.GetCardinality(), "mask %#x", mask)
+			for _, v := range expected.ToArray() {
+				require.True(t, ra.Contains(v), "mask %#x missing %d", mask, v)
+			}
+		}
+	})
+
+	t.Run("matches ra.Clone().And(b.Masked(mask))", func(t *testing.T) {
+		masks := []uint64{0, 0x0000FFFFFFFFFFFF, math.MaxUint64, 0x00000000FFFF0000}
+
+		b := NewBitmap()
+		for pos := uint64(0); pos < 5; pos++ {
+			for v := uint64(0); v < 100; v++ {
+				b.Set(pos<<48 | v)
+			}
+		}
+
+		for _, mask := range masks {
+			ra := NewBitmap()
+			for pos := uint64(0); pos < 3; pos++ {
+				for v := uint64(0); v < 100; v++ {
+					ra.Set(pos<<48 | v)
+				}
+			}
+
+			expected := ra.Clone()
+			expected.And(b.Masked(mask))
+
+			ra.AndMasked(b, mask)
+
+			require.Equal(t, expected.GetCardinality(), ra.GetCardinality(), "mask %#x", mask)
+			for _, v := range expected.ToArray() {
+				require.True(t, ra.Contains(v), "mask %#x missing %d", mask, v)
+			}
+		}
+	})
+
+	t.Run("zero mask collapses all b keys to zero", func(t *testing.T) {
+		ra := NewBitmap()
+		ra.Set(0x00000000 | 1) // key 0, value 1
+		ra.Set(0x00000000 | 2) // key 0, value 2
+		ra.Set(0x00010000 | 3) // key 1, value 3 — no b key maps here under zero mask
+
+		b := NewBitmap()
+		b.Set(0x00010000 | 1) // key 1 → masked 0, value 1
+		b.Set(0x00020000 | 2) // key 2 → masked 0, value 2
+
+		// Masked(b) at key 0 = OR({1}, {2}) = {1, 2}
+		// ra[key 0] AND {1, 2} = {1, 2} AND {1, 2} = {1, 2}
+		// ra[key 1] has no match → zeroed
+		ra.AndMasked(b, 0)
+
+		require.Equal(t, 2, ra.GetCardinality())
+		require.True(t, ra.Contains(1))
+		require.True(t, ra.Contains(2))
+		require.False(t, ra.Contains(0x00010000|3))
+	})
+
+	t.Run("b not modified", func(t *testing.T) {
+		ra := NewBitmap()
+		b := NewBitmap()
+		for i := uint64(0); i < 100; i++ {
+			ra.Set(i)
+			b.Set(uint64(1)<<48 | i)
+		}
+		bCard := b.GetCardinality()
+		bValues := b.ToArray()
+
+		ra.AndMasked(b, 0x0000FFFFFFFFFFFF)
+
+		require.Equal(t, bCard, b.GetCardinality())
+		for _, v := range bValues {
+			require.True(t, b.Contains(v))
+		}
+	})
+
+	t.Run("multiple b keys OR before AND", func(t *testing.T) {
+		ra := NewBitmap()
+		// key 0: values {0, 1, 2, 3}
+		for v := uint64(0); v <= 3; v++ {
+			ra.Set(v)
+		}
+
+		b := NewBitmap()
+		// Two b keys both masked to 0: first has {1,2}, second has {3,4}
+		// OR = {1,2,3,4}; AND with ra[key 0]={0,1,2,3} = {1,2,3}
+		b.Set(0x00010000 | 1)
+		b.Set(0x00010000 | 2)
+		b.Set(0x00020000 | 3)
+		b.Set(0x00020000 | 4)
+
+		ra.AndMasked(b, 0)
+
+		require.Equal(t, 3, ra.GetCardinality())
+		require.True(t, ra.Contains(1))
+		require.True(t, ra.Contains(2))
+		require.True(t, ra.Contains(3))
+		require.False(t, ra.Contains(0))
+		require.False(t, ra.Contains(4))
+	})
+
+	// The next four tests target the buffer-swap logic in the OR accumulation loop.
+	// The source container (orBuf) is always exactly-sized after copying group[0],
+	// so any non-overlapping element OR'd in will not fit inline — the result
+	// lands in fallbackBuf and the two buffers are swapped.
+
+	t.Run("non-overlapping arrays: inline fails due to size, buffers swapped", func(t *testing.T) {
+		// group[0] has 50 elements → orBuf.indexSize = 54 (4 header + 50 values).
+		// group[1] adds 50 non-overlapping elements → result needs indexSize 104.
+		// 54 < 104 → inline fails, result is in fallbackBuf, swap occurs.
+		ra := NewBitmap()
+		for v := uint64(0); v < 100; v++ {
+			ra.Set(v)
+		}
+
+		b := NewBitmap()
+		for v := uint64(0); v < 50; v++ {
+			b.Set(0x00010000 | v) // key 1 → masked 0, values 0-49
+		}
+		for v := uint64(50); v < 100; v++ {
+			b.Set(0x00020000 | v) // key 2 → masked 0, values 50-99
+		}
+
+		ra.AndMasked(b, 0)
+
+		require.Equal(t, 100, ra.GetCardinality())
+		for v := uint64(0); v < 100; v++ {
+			require.True(t, ra.Contains(v))
+		}
+	})
+
+	t.Run("overlapping arrays: inline succeeds, no swap", func(t *testing.T) {
+		// group[0] and group[1] have identical values → OR result cardinality
+		// equals group[0] cardinality → fits within orBuf.indexSize → no swap.
+		ra := NewBitmap()
+		for v := uint64(0); v < 50; v++ {
+			ra.Set(v)
+		}
+
+		b := NewBitmap()
+		for v := uint64(0); v < 50; v++ {
+			b.Set(0x00010000 | v) // key 1 → masked 0, values 0-49
+		}
+		for v := uint64(0); v < 50; v++ {
+			b.Set(0x00020000 | v) // key 2 → masked 0, same values 0-49
+		}
+
+		ra.AndMasked(b, 0)
+
+		require.Equal(t, 50, ra.GetCardinality())
+		for v := uint64(0); v < 50; v++ {
+			require.True(t, ra.Contains(v))
+		}
+	})
+
+	t.Run("large non-overlapping arrays: bitmap conversion triggers swap", func(t *testing.T) {
+		// cnum + onum = 1228 + 1228 = 2456 >= 2456 → array-to-bitmap conversion.
+		// Source container has indexSize = 1232 < maxContainerSize → inline fails,
+		// result (bitmap) lands in fallbackBuf, buffers are swapped.
+		const half = 1228 // cnum + onum == 2456 == maxContainerSize/5*3 - startIdx
+
+		ra := NewBitmap()
+		for v := uint64(0); v < 2*half; v++ {
+			ra.Set(v)
+		}
+
+		b := NewBitmap()
+		for v := uint64(0); v < half; v++ {
+			b.Set(0x00010000 | v) // key 1 → masked 0, values 0-1227
+		}
+		for v := uint64(half); v < 2*half; v++ {
+			b.Set(0x00020000 | v) // key 2 → masked 0, values 1228-2455
+		}
+
+		ra.AndMasked(b, 0)
+
+		require.Equal(t, 2*half, ra.GetCardinality())
+		for v := uint64(0); v < 2*half; v++ {
+			require.True(t, ra.Contains(v))
+		}
+	})
+
+	t.Run("three containers: swap on first pair, then OR into bitmap succeeds inline", func(t *testing.T) {
+		// First OR triggers bitmap conversion and swap (result now in orBuf as bitmap).
+		// Second OR is bitmap+array: inline always succeeds, fallbackBuf unused.
+		// Verifies that orResult correctly points into orBuf after the swap.
+		const half = 1228
+
+		ra := NewBitmap()
+		for v := uint64(0); v < 3*half; v++ {
+			ra.Set(v)
+		}
+
+		b := NewBitmap()
+		for v := uint64(0); v < half; v++ {
+			b.Set(0x00010000 | v) // key 1 → masked 0
+		}
+		for v := uint64(half); v < 2*half; v++ {
+			b.Set(0x00020000 | v) // key 2 → masked 0, triggers swap with key 1
+		}
+		for v := uint64(2*half); v < 3*half; v++ {
+			b.Set(0x00030000 | v) // key 3 → masked 0, OR'd into bitmap inline
+		}
+
+		ra.AndMasked(b, 0)
+
+		require.Equal(t, 3*half, ra.GetCardinality())
+		for v := uint64(0); v < 3*half; v++ {
+			require.True(t, ra.Contains(v))
+		}
+	})
+}
+
+func TestAndMaskedConc(t *testing.T) {
+	// n is large enough to guarantee at least 2 goroutines:
+	// calcConcurrency uses minContainersPerRoutine=24, so n >= 48 gives concurrency >= 2.
+	const n = minContainersPerRoutine * 3 // 72 keys
+
+	// mask keeps bits 16-31 and zeroes bits 32-63.
+	// b keys at (g<<32 | k<<16) all map to ra key (k<<16) under this mask.
+	const mask uint64 = 0x00000000FFFF0000
+
+	// assertMatchesSeq verifies that AndMaskedConc produces the same result as
+	// AndMasked at several concurrency levels, including one that forces
+	// actual goroutine spawning (maxConc=0 means unlimited).
+	assertMatchesSeq := func(t *testing.T, ra, b *Bitmap, m uint64) {
+		t.Helper()
+		expected := ra.Clone()
+		expected.AndMasked(b, m)
+		for _, maxConc := range []int{1, 2, 4, 0} {
+			got := ra.Clone()
+			got.AndMaskedConc(b, m, maxConc)
+			require.Equal(t, expected.GetCardinality(), got.GetCardinality(), "maxConc=%d", maxConc)
+			for _, v := range expected.ToArray() {
+				require.True(t, got.Contains(v), "maxConc=%d missing %d", maxConc, v)
+			}
+		}
+	}
+
+	t.Run("empty b zeroes ra", func(t *testing.T) {
+		ra := NewBitmap()
+		ra.Set(1)
+		ra.AndMaskedConc(NewBitmap(), math.MaxUint64, 0)
+		require.Equal(t, 0, ra.GetCardinality())
+	})
+
+	t.Run("nil b zeroes ra", func(t *testing.T) {
+		ra := NewBitmap()
+		ra.Set(1)
+		var b *Bitmap
+		ra.AndMaskedConc(b, math.MaxUint64, 0)
+		require.Equal(t, 0, ra.GetCardinality())
+	})
+
+	t.Run("identity mask", func(t *testing.T) {
+		// Mirror of TestAndMasked/identity_mask_matches_ra.And(b).
+		// n ra keys, b has same keys with even-valued elements only.
+		ra := NewBitmap()
+		b := NewBitmap()
+		for k := uint64(0); k < n; k++ {
+			for v := uint64(0); v < 200; v++ {
+				ra.Set(k<<16 | v)
+				if v%2 == 0 {
+					b.Set(k<<16 | v)
+				}
+			}
+		}
+		assertMatchesSeq(t, ra, b, math.MaxUint64)
+	})
+
+	t.Run("matches AndMasked across masks", func(t *testing.T) {
+		// Mirror of TestAndMasked/matches_ra.Clone().And(b.Masked(mask)).
+		// n ra keys; b spreads the same keys across 5 high-bit positions.
+		ra := NewBitmap()
+		b := NewBitmap()
+		for k := uint64(0); k < n; k++ {
+			for v := uint64(0); v < 100; v++ {
+				ra.Set(k<<16 | v)
+			}
+			for pos := uint64(0); pos < 5; pos++ {
+				for v := uint64(0); v < 100; v++ {
+					b.Set(pos<<32 | k<<16 | v)
+				}
+			}
+		}
+		for _, m := range []uint64{0, 0x0000FFFFFFFFFFFF, math.MaxUint64, mask} {
+			assertMatchesSeq(t, ra, b, m)
+		}
+	})
+
+	t.Run("zero mask: most ra containers zeroed out", func(t *testing.T) {
+		// Mirror of TestAndMasked/zero_mask_collapses_all_b_keys_to_zero.
+		// Under mask=0 only ra key 0 has a match; all others are zeroed.
+		// This exercises the zero-out path across n-1 containers concurrently.
+		ra := NewBitmap()
+		b := NewBitmap()
+		for k := uint64(0); k < n; k++ {
+			ra.Set(k<<16 | 1)
+			ra.Set(k<<16 | 2)
+		}
+		b.Set(0x00010000 | 1) // maps to masked key 0
+		b.Set(0x00020000 | 2) // maps to masked key 0
+		assertMatchesSeq(t, ra, b, 0)
+	})
+
+	t.Run("multiple b keys OR before AND", func(t *testing.T) {
+		// Mirror of TestAndMasked/multiple_b_keys_OR_before_AND.
+		// Each ra key has 2 b keys mapping to it; OR triggers buffer swap
+		// (non-overlapping arrays, result doesn't fit in source container).
+		ra := NewBitmap()
+		b := NewBitmap()
+		for k := uint64(0); k < n; k++ {
+			for v := uint64(0); v <= 3; v++ {
+				ra.Set(k<<16 | v)
+			}
+			b.Set(uint64(1)<<32 | k<<16 | 1)
+			b.Set(uint64(1)<<32 | k<<16 | 2)
+			b.Set(uint64(2)<<32 | k<<16 | 3)
+			b.Set(uint64(2)<<32 | k<<16 | 4)
+		}
+		assertMatchesSeq(t, ra, b, mask)
+	})
+
+	t.Run("overlapping arrays: inline OR succeeds without swap", func(t *testing.T) {
+		// Mirror of TestAndMasked/overlapping_arrays:_inline_succeeds,_no_swap.
+		// Two b keys per ra key with identical values — OR result fits in source.
+		ra := NewBitmap()
+		b := NewBitmap()
+		for k := uint64(0); k < n; k++ {
+			for v := uint64(0); v < 50; v++ {
+				ra.Set(k<<16 | v)
+				b.Set(uint64(1)<<32 | k<<16 | v)
+				b.Set(uint64(2)<<32 | k<<16 | v)
+			}
+		}
+		assertMatchesSeq(t, ra, b, mask)
+	})
+
+	t.Run("large non-overlapping arrays: bitmap conversion triggers swap", func(t *testing.T) {
+		// Mirror of TestAndMasked/large_non-overlapping_arrays.
+		// Per ra key: two b keys with 1228 non-overlapping values each →
+		// cnum+onum=2456 triggers array-to-bitmap conversion and buffer swap.
+		const half = 1228
+		ra := NewBitmap()
+		b := NewBitmap()
+		for k := uint64(0); k < n; k++ {
+			for v := uint64(0); v < 2*half; v++ {
+				ra.Set(k<<16 | v)
+			}
+			for v := uint64(0); v < half; v++ {
+				b.Set(uint64(1)<<32 | k<<16 | v)
+			}
+			for v := uint64(half); v < 2*half; v++ {
+				b.Set(uint64(2)<<32 | k<<16 | v)
+			}
+		}
+		assertMatchesSeq(t, ra, b, mask)
+	})
+
+	t.Run("three containers: swap then OR into bitmap", func(t *testing.T) {
+		// Mirror of TestAndMasked/three_containers:_swap_on_first_pair.
+		// Per ra key: first pair triggers bitmap conversion and swap;
+		// third container is OR'd inline into the resulting bitmap.
+		const half = 1228
+		ra := NewBitmap()
+		b := NewBitmap()
+		for k := uint64(0); k < n; k++ {
+			for v := uint64(0); v < 3*half; v++ {
+				ra.Set(k<<16 | v)
+			}
+			for v := uint64(0); v < half; v++ {
+				b.Set(uint64(1)<<32 | k<<16 | v)
+			}
+			for v := uint64(half); v < 2*half; v++ {
+				b.Set(uint64(2)<<32 | k<<16 | v)
+			}
+			for v := uint64(2*half); v < 3*half; v++ {
+				b.Set(uint64(3)<<32 | k<<16 | v)
+			}
+		}
+		assertMatchesSeq(t, ra, b, mask)
+	})
+
+	t.Run("b not modified", func(t *testing.T) {
+		ra := NewBitmap()
+		b := NewBitmap()
+		for k := uint64(0); k < n; k++ {
+			for v := uint64(0); v < 50; v++ {
+				ra.Set(k<<16 | v)
+				b.Set(uint64(1)<<32 | k<<16 | v)
+				b.Set(uint64(2)<<32 | k<<16 | v)
+			}
+		}
+		bCard := b.GetCardinality()
+		bValues := b.ToArray()
+
+		ra.AndMaskedConc(b, mask, 0)
+
+		require.Equal(t, bCard, b.GetCardinality())
+		for _, v := range bValues {
+			require.True(t, b.Contains(v))
+		}
+	})
+}

--- a/bitmap_opt_test.go
+++ b/bitmap_opt_test.go
@@ -2,6 +2,7 @@ package sroar
 
 import (
 	"fmt"
+	"math"
 	"math/bits"
 	"math/rand"
 	"slices"
@@ -2714,5 +2715,167 @@ func TestCalcConcurrency(t *testing.T) {
 
 	t.Run("maxConcurrency equal to calculated returns calculated", func(t *testing.T) {
 		require.Equal(t, 4, calcConcurrency(96, 24, 4))
+	})
+}
+
+func TestMaskedAnd(t *testing.T) {
+	t.Run("nil inputs", func(t *testing.T) {
+		var a, b *Bitmap
+		require.Equal(t, 0, MaskedAnd(a, b, math.MaxUint64).GetCardinality())
+		require.Equal(t, 0, MaskedAnd(NewBitmap(), b, math.MaxUint64).GetCardinality())
+		require.Equal(t, 0, MaskedAnd(a, NewBitmap(), math.MaxUint64).GetCardinality())
+	})
+
+	t.Run("empty inputs", func(t *testing.T) {
+		require.Equal(t, 0, MaskedAnd(NewBitmap(), NewBitmap(), math.MaxUint64).GetCardinality())
+	})
+
+	t.Run("no overlap produces empty result", func(t *testing.T) {
+		a := NewBitmap()
+		a.Set(0x00010000)
+		a.Set(0x00010001)
+
+		b := NewBitmap()
+		b.Set(0x00020000)
+		b.Set(0x00020001)
+
+		result := MaskedAnd(a, b, math.MaxUint64)
+		require.Equal(t, 0, result.GetCardinality())
+	})
+
+	t.Run("matches Masked(And(a,b))", func(t *testing.T) {
+		masks := []uint64{0, 0x0000FFFFFFFFFFFF, math.MaxUint64, 0x00000000FFFF0000}
+
+		a := NewBitmap()
+		b := NewBitmap()
+		for pos := uint64(0); pos < 5; pos++ {
+			for v := uint64(0); v < 100; v++ {
+				a.Set(pos<<48 | v)
+				// b overlaps on even positions only
+				if pos%2 == 0 {
+					b.Set(pos<<48 | v)
+				}
+			}
+		}
+
+		for _, m := range masks {
+			expected := And(a, b).Masked(m)
+			got := MaskedAnd(a, b, m)
+
+			require.Equal(t, expected.GetCardinality(), got.GetCardinality(), "mask %#x", m)
+			for _, v := range expected.ToArray() {
+				require.True(t, got.Contains(v), "mask %#x missing %d", m, v)
+			}
+		}
+	})
+
+	t.Run("key collision after masking merges via OR", func(t *testing.T) {
+		// Two key pairs that AND to non-empty, both mapping to same masked key.
+		a := NewBitmap()
+		b := NewBitmap()
+
+		// pos=1: a has {0,1}, b has {0,1} → AND = {0,1}
+		a.Set(0x0001_0000_0000 | 0)
+		a.Set(0x0001_0000_0000 | 1)
+		b.Set(0x0001_0000_0000 | 0)
+		b.Set(0x0001_0000_0000 | 1)
+
+		// pos=2: a has {2,3}, b has {2,3} → AND = {2,3}
+		a.Set(0x0002_0000_0000 | 2)
+		a.Set(0x0002_0000_0000 | 3)
+		b.Set(0x0002_0000_0000 | 2)
+		b.Set(0x0002_0000_0000 | 3)
+
+		// mask zeroes bits 32-63 → both key pairs collapse to masked key 0
+		result := MaskedAnd(a, b, 0x00000000FFFF0000)
+
+		require.Equal(t, 4, result.GetCardinality())
+		require.True(t, result.Contains(0))
+		require.True(t, result.Contains(1))
+		require.True(t, result.Contains(2))
+		require.True(t, result.Contains(3))
+	})
+
+	t.Run("does not modify either source", func(t *testing.T) {
+		a := NewBitmap()
+		a.Set(uint64(1)<<48 | 10)
+		a.Set(uint64(2)<<48 | 20)
+
+		b := NewBitmap()
+		b.Set(uint64(1)<<48 | 10)
+		b.Set(uint64(3)<<48 | 30)
+
+		aCard := a.GetCardinality()
+		bCard := b.GetCardinality()
+		_ = MaskedAnd(a, b, 0x0000FFFFFFFFFFFF)
+
+		require.Equal(t, aCard, a.GetCardinality())
+		require.Equal(t, bCard, b.GetCardinality())
+		require.True(t, a.Contains(uint64(1)<<48|10))
+		require.True(t, a.Contains(uint64(2)<<48|20))
+		require.True(t, b.Contains(uint64(1)<<48|10))
+		require.True(t, b.Contains(uint64(3)<<48|30))
+	})
+
+	t.Run("low 16 bits of mask are ignored", func(t *testing.T) {
+		a := NewBitmap()
+		b := NewBitmap()
+		a.Set(uint64(1)<<48 | 1)
+		b.Set(uint64(1)<<48 | 1)
+
+		r1 := MaskedAnd(a, b, 0x0000FFFFFFFFFFFF)
+		r2 := MaskedAnd(a, b, 0x0000FFFFFFFFFFFF|0xFFFF)
+
+		require.Equal(t, r1.GetCardinality(), r2.GetCardinality())
+		for _, v := range r1.ToArray() {
+			require.True(t, r2.Contains(v))
+		}
+	})
+}
+
+func TestMaskedAndToBuf(t *testing.T) {
+	t.Run("nil inputs", func(t *testing.T) {
+		var a, b *Bitmap
+		result := MaskedAndToBuf(a, b, math.MaxUint64, make([]byte, 4096))
+		require.Equal(t, 0, result.GetCardinality())
+	})
+
+	t.Run("matches MaskedAnd results", func(t *testing.T) {
+		a := NewBitmap()
+		b := NewBitmap()
+		for pos := uint64(0); pos < 5; pos++ {
+			for v := uint64(0); v < 100; v++ {
+				a.Set(pos<<48 | v)
+				b.Set(pos<<48 | v)
+			}
+		}
+
+		masks := []uint64{0, 0x0000FFFFFFFFFFFF, math.MaxUint64, 0x00000000FFFF0000}
+		for _, m := range masks {
+			expected := MaskedAnd(a, b, m)
+			got := MaskedAndToBuf(a, b, m, make([]byte, 1<<20))
+
+			require.Equal(t, expected.GetCardinality(), got.GetCardinality(), "mask %#x", m)
+			for _, v := range expected.ToArray() {
+				require.True(t, got.Contains(v), "mask %#x missing %d", m, v)
+			}
+		}
+	})
+
+	t.Run("no allocation when buffer is large enough", func(t *testing.T) {
+		a := NewBitmap()
+		b := NewBitmap()
+		for pos := uint64(0); pos < 5; pos++ {
+			for v := uint64(0); v < 100; v++ {
+				a.Set(pos<<48 | v)
+				b.Set(pos<<48 | v)
+			}
+		}
+
+		bufSize := 1 << 20
+		result := MaskedAndToBuf(a, b, 0x0000FFFFFFFFFFFF, make([]byte, bufSize))
+
+		require.Greater(t, result.GetCardinality(), 0)
+		require.Equal(t, bufSize, result.capInBytes(), "capacity should not change")
 	})
 }

--- a/bitmap_opt_test.go
+++ b/bitmap_opt_test.go
@@ -3317,3 +3317,54 @@ func TestAndMaskedConc(t *testing.T) {
 		}
 	})
 }
+
+// TestAndMaskedDimAware confirms that AndMasked and AndMaskedConc correctly
+// handle dim-aware ra bitmaps (keys with non-zero low 16 bits).
+//
+// Bug: andMaskedContainersInRange calls maskedEntriesFor(entries, ak, from)
+// where entries have maskedKey = bk & 0xFFFFFFFFFFFF0000 (low bits zeroed)
+// but ak is a dim-aware key with non-zero low bits. The exact match can never
+// succeed, so all ra containers are silently zeroed regardless of b's content.
+func TestAndMaskedDimAware(t *testing.T) {
+	// ra has a single value stored under dim=1.
+	// b has the same value stored under dim=0 (plain Set).
+	// Under mask=0xFFFFFFFFFFFF0000 the two keys collapse to the same masked
+	// key, so the AND should leave ra's container intact (value present in both).
+	const (
+		val  = uint64(0x00010001) // upper 48 bits = 0x00010000, lower 16 = 0x0001
+		dim  = uint16(1)
+		mask = uint64(0xFFFFFFFFFFFF0000)
+	)
+
+	t.Run("AndMasked: dim-aware ra is not zeroed when b has matching value", func(t *testing.T) {
+		ra := NewBitmap()
+		ra.SetDim(val, dim) // key = 0x00010001, container value = 0x0001
+
+		b := NewBitmap()
+		b.Set(val) // key = 0x00010000, container value = 0x0001
+
+		ra.AndMasked(b, mask)
+
+		// ra key 0x00010001 masked = 0x00010000
+		// b  key 0x00010000 masked = 0x00010000  → match → container survives AND
+		require.Equal(t, 1, ra.GetCardinalityDim(dim),
+			"dim=1 container should survive: b has a matching value under the mask")
+		require.True(t, ra.ContainsDim(val, dim),
+			"value should still be present in dim=1 after AndMasked")
+	})
+
+	t.Run("AndMaskedConc: dim-aware ra is not zeroed when b has matching value", func(t *testing.T) {
+		ra := NewBitmap()
+		ra.SetDim(val, dim)
+
+		b := NewBitmap()
+		b.Set(val)
+
+		ra.AndMaskedConc(b, mask, 0)
+
+		require.Equal(t, 1, ra.GetCardinalityDim(dim),
+			"dim=1 container should survive: b has a matching value under the mask")
+		require.True(t, ra.ContainsDim(val, dim),
+			"value should still be present in dim=1 after AndMaskedConc")
+	})
+}

--- a/bitmap_test.go
+++ b/bitmap_test.go
@@ -1649,3 +1649,353 @@ func TestZeroOut(t *testing.T) {
 		require.Equal(t, bmTemplate.capInBytes(), bm.capInBytes())
 	})
 }
+
+func TestRemoveDim(t *testing.T) {
+	dims := uint16(3)
+	a := NewBitmap()
+	N := int(1e7)
+
+	for dim := uint16(0); dim < dims; dim++ {
+		for i := 0; i < N; i++ {
+			a.SetDim(uint64(i), dim)
+		}
+	}
+
+	for dim := uint16(0); dim < dims; dim++ {
+		require.Equal(t, N, a.GetCardinalityDim(dim))
+		for i := 0; i < N/2; i++ {
+			require.True(t, a.RemoveDim(uint64(i), dim))
+		}
+		require.Equal(t, N/2, a.GetCardinalityDim(dim))
+	}
+
+	// Remove non-existent elements should be no-op
+	for dim := uint16(0); dim < dims; dim++ {
+		for i := 0; i < N/2; i++ {
+			require.False(t, a.RemoveDim(uint64(i), dim))
+		}
+		require.Equal(t, N/2, a.GetCardinalityDim(dim))
+	}
+
+	for dim := uint16(0); dim < dims; dim++ {
+		for i := 0; i < N/2; i++ {
+			require.True(t, a.RemoveDim(uint64(i+N/2), dim))
+		}
+		require.Equal(t, 0, a.GetCardinalityDim(dim))
+	}
+}
+
+func TestCardinalityDim(t *testing.T) {
+	dims := uint16(3)
+	a := NewBitmap()
+	n := 1 << 20
+
+	for dim := uint16(0); dim < dims; dim++ {
+		for i := 0; i < n; i++ {
+			a.SetDim(uint64(i), dim)
+		}
+		require.Equal(t, n, a.GetCardinalityDim(dim))
+	}
+}
+
+func TestCleanupDim(t *testing.T) {
+	dim := uint16(2)
+	a := NewBitmap()
+	n := 10
+	for i := 0; i < n; i++ {
+		a.SetDim(uint64(i*(1<<16)), dim)
+	}
+	require.Equal(t, n, a.GetCardinalityDim(dim))
+	require.Equal(t, n+1, a.keys.numKeys())
+
+	for i := 0; i < n; i++ {
+		if i%2 == 1 {
+			a.RemoveDim(uint64(i*(1<<16)), dim)
+		}
+	}
+	require.Equal(t, n/2, a.GetCardinalityDim(dim))
+	require.Equal(t, n+1, a.keys.numKeys())
+
+	a.Cleanup()
+	require.Equal(t, n/2, a.GetCardinalityDim(dim))
+	require.Equal(t, n/2+1, a.keys.numKeys())
+}
+
+func TestContainsDim(t *testing.T) {
+	bm := NewBitmap()
+	dims := uint16(4)
+	firstX := uint64(12345)
+
+	x := firstX
+	for i := uint16(0); i < 99; i++ {
+		dim := i % dims
+		bm.SetDim(x, dim)
+		x += uint64(maxCardinality) / 5
+	}
+
+	x = firstX
+	for i := uint16(0); i < 99; i++ {
+		for dim := uint16(0); dim < dims; dim++ {
+			if dim == i%dims {
+				require.True(t, bm.ContainsDim(x, dim))
+			} else {
+				require.False(t, bm.ContainsDim(x, dim))
+			}
+		}
+		x += uint64(maxCardinality) / 5
+	}
+}
+
+func TestToArrayDim(t *testing.T) {
+	bm := NewBitmap()
+	dims := uint16(4)
+	firstX := uint64(12345)
+
+	control := make([][]uint64, dims)
+	for v := range control {
+		control[v] = []uint64{}
+	}
+
+	x := firstX
+	for i := uint16(0); i < 99; i++ {
+		dim := i % dims
+		bm.SetDim(x, dim)
+		control[dim] = append(control[dim], x)
+		x += uint64(maxCardinality) / 5
+	}
+
+	for dim := range control {
+		arr := bm.ToArrayDim(uint16(dim))
+		require.ElementsMatch(t, control[dim], arr)
+	}
+}
+
+func TestRemoveRangeDim(t *testing.T) {
+	dims := uint16(3)
+	a := NewBitmap()
+	N := int(1e7)
+	for i := 0; i < N; i++ {
+		for dim := uint16(0); dim < dims; dim++ {
+			a.SetDim(uint64(i), dim)
+		}
+	}
+
+	for dim := uint16(0); dim < dims; dim++ {
+		a.RemoveRangeDim(0, 0, dim)
+		require.Equal(t, N, a.GetCardinalityDim(dim))
+	}
+
+	for dim := uint16(0); dim < dims; dim++ {
+		a.RemoveRangeDim(uint64(N/4), uint64(N/2), dim)
+		require.Equal(t, 3*N/4, a.GetCardinalityDim(dim))
+	}
+
+	for dim := uint16(0); dim < dims; dim++ {
+		a.RemoveRangeDim(0, uint64(N/2), dim)
+		require.Equal(t, N/2, a.GetCardinalityDim(dim))
+	}
+
+	for dim := uint16(0); dim < dims; dim++ {
+		a.RemoveRangeDim(uint64(N/2), uint64(N), dim)
+		require.Equal(t, 0, a.GetCardinalityDim(dim))
+		a.SetDim(uint64(N/4), dim)
+		a.SetDim(uint64(N/2), dim)
+		a.SetDim(uint64(3*N/4), dim)
+		require.Equal(t, 3, a.GetCardinalityDim(dim))
+	}
+
+	var arr []uint64
+	for i := 0; i < 123; i++ {
+		arr = append(arr, uint64(i))
+	}
+
+	for dim := uint16(0); dim < dims; dim++ {
+		b := FromSortedListDim(arr, dim)
+		b.RemoveRangeDim(50, math.MaxUint64, dim)
+		require.Equal(t, 50, b.GetCardinalityDim(dim))
+	}
+}
+
+func TestRemoveRangeDim2(t *testing.T) {
+	dims := uint16(3)
+	// High from the last container should not be removed.
+	a := NewBitmap()
+	for i := 1; i < 10; i++ {
+		for dim := uint16(0); dim < dims; dim++ {
+			a.SetDim(uint64(i*(1<<16)), dim)
+			a.SetDim(uint64(i*(1<<16))-1, dim)
+		}
+	}
+	for dim := uint16(0); dim < dims; dim++ {
+		a.RemoveRangeDim(1<<16, (4<<16)-1, dim)
+		require.True(t, a.ContainsDim((4<<16)-1, dim))
+	}
+}
+
+func TestMergeDims(t *testing.T) {
+	t.Run("original large test", func(t *testing.T) {
+		dims := uint16(3)
+		firstX := uint64(1234)
+		bm := NewBitmap()
+
+		x := firstX
+		for i := 0; i < 10000; i++ {
+			dim := uint16(i) % dims
+			bm.SetDim(x, dim)
+			x += uint64(maxCardinality) / 307
+		}
+
+		merged := bm.MergeDims()
+		it := merged.NewIterator()
+
+		x = firstX
+		for i := 0; i < 10000; i++ {
+			xx := it.Next()
+			require.Equal(t, x, xx)
+			x += uint64(maxCardinality) / 307
+		}
+	})
+
+	t.Run("no bitmap", func(t *testing.T) {
+		var bm *Bitmap
+		result := bm.MergeDims()
+		require.Equal(t, 0, result.GetCardinality())
+	})
+
+	t.Run("empty bitmap", func(t *testing.T) {
+		bm := NewBitmap()
+		result := bm.MergeDims()
+		require.Equal(t, 0, result.GetCardinality())
+	})
+
+	t.Run("single dim is identity", func(t *testing.T) {
+		bm := NewBitmap()
+		bm.SetDim(0x0001_0000|10, 0)
+		bm.SetDim(0x0001_0000|20, 0)
+		bm.SetDim(0x0002_0000|30, 0)
+
+		result := bm.MergeDims()
+
+		require.Equal(t, 3, result.GetCardinality())
+		require.True(t, result.Contains(0x0001_0000|10))
+		require.True(t, result.Contains(0x0001_0000|20))
+		require.True(t, result.Contains(0x0002_0000|30))
+	})
+
+	t.Run("different dims same value merge", func(t *testing.T) {
+		bm := NewBitmap()
+		// Same value, different dims — should merge to one container.
+		bm.SetDim(0x0001_0000|5, 0)
+		bm.SetDim(0x0001_0000|6, 1)
+		bm.SetDim(0x0001_0000|7, 2)
+
+		result := bm.MergeDims()
+
+		require.Equal(t, 3, result.GetCardinality())
+		require.True(t, result.Contains(0x0001_0000|5))
+		require.True(t, result.Contains(0x0001_0000|6))
+		require.True(t, result.Contains(0x0001_0000|7))
+	})
+
+	t.Run("different dims overlapping values merge via OR", func(t *testing.T) {
+		bm := NewBitmap()
+		// Overlapping values across dims — OR should deduplicate.
+		bm.SetDim(0x0001_0000|10, 0)
+		bm.SetDim(0x0001_0000|10, 1) // same value, different dim
+		bm.SetDim(0x0001_0000|20, 1)
+
+		result := bm.MergeDims()
+
+		require.Equal(t, 2, result.GetCardinality())
+		require.True(t, result.Contains(0x0001_0000|10))
+		require.True(t, result.Contains(0x0001_0000|20))
+	})
+
+	t.Run("many dims collapsing", func(t *testing.T) {
+		bm := NewBitmap()
+		numDims := uint16(10)
+		numValues := uint64(100)
+
+		for dim := uint16(0); dim < numDims; dim++ {
+			for v := uint64(0); v < numValues; v++ {
+				bm.SetDim(v, dim)
+			}
+		}
+
+		result := bm.MergeDims()
+
+		require.Equal(t, int(numValues), result.GetCardinality())
+		for v := uint64(0); v < numValues; v++ {
+			require.True(t, result.Contains(v))
+		}
+	})
+
+	t.Run("does not modify original", func(t *testing.T) {
+		bm := NewBitmap()
+		bm.SetDim(0x0001_0000|10, 0)
+		bm.SetDim(0x0001_0000|20, 1)
+
+		origCard := bm.GetCardinalityDim(0) + bm.GetCardinalityDim(1)
+		_ = bm.MergeDims()
+
+		require.Equal(t, origCard, bm.GetCardinalityDim(0)+bm.GetCardinalityDim(1))
+		require.True(t, bm.ContainsDim(0x0001_0000|10, 0))
+		require.True(t, bm.ContainsDim(0x0001_0000|20, 1))
+	})
+
+	t.Run("multiple keys multiple dims", func(t *testing.T) {
+		bm := NewBitmap()
+		// Key 0x0001_0000: dim 0 has {1,2}, dim 1 has {2,3}
+		bm.SetDim(0x0001_0000|1, 0)
+		bm.SetDim(0x0001_0000|2, 0)
+		bm.SetDim(0x0001_0000|2, 1)
+		bm.SetDim(0x0001_0000|3, 1)
+		// Key 0x0002_0000: dim 0 has {10}, dim 2 has {20}
+		bm.SetDim(0x0002_0000|10, 0)
+		bm.SetDim(0x0002_0000|20, 2)
+
+		result := bm.MergeDims()
+
+		// Key 0x0001_0000: OR of {1,2} and {2,3} = {1,2,3}
+		require.True(t, result.Contains(0x0001_0000|1))
+		require.True(t, result.Contains(0x0001_0000|2))
+		require.True(t, result.Contains(0x0001_0000|3))
+		// Key 0x0002_0000: OR of {10} and {20} = {10,20}
+		require.True(t, result.Contains(0x0002_0000|10))
+		require.True(t, result.Contains(0x0002_0000|20))
+
+		require.Equal(t, 5, result.GetCardinality())
+	})
+}
+
+func TestToMapDims(t *testing.T) {
+	bm := NewBitmap()
+
+	bm.Set(0)
+	bm.SetDim(1, 0)
+	bm.SetDim(1, 1)
+	bm.SetDim(2, 0)
+	bm.SetDim(2, 1)
+	bm.SetDim(2, 2)
+	bm.SetDim(3, 0)
+	bm.SetDim(3, 1)
+	bm.SetDim(3, 2)
+	bm.SetDim(3, 3)
+	bm.SetDim(4, 2)
+	bm.SetDim(4, 3)
+	bm.SetDim(4, 4)
+	bm.SetDim(5, 4)
+	bm.SetDim(5, 5)
+	bm.SetDim(6, 6)
+
+	mp := bm.ToMapDims()
+
+	require.Len(t, mp, 7)
+	require.ElementsMatch(t, []uint16{0}, mp[0])
+	require.ElementsMatch(t, []uint16{0, 1}, mp[1])
+	require.ElementsMatch(t, []uint16{0, 1, 2}, mp[2])
+	require.ElementsMatch(t, []uint16{0, 1, 2, 3}, mp[3])
+	require.ElementsMatch(t, []uint16{2, 3, 4}, mp[4])
+	require.ElementsMatch(t, []uint16{4, 5}, mp[5])
+	require.ElementsMatch(t, []uint16{6}, mp[6])
+}

--- a/iterator.go
+++ b/iterator.go
@@ -25,6 +25,7 @@ type Iterator struct {
 
 	keys   []uint64
 	keyIdx int
+	dim    uint16
 
 	contIdx int
 
@@ -54,58 +55,78 @@ func (bm *Bitmap) NewRangeIterators(numRanges int) []*Iterator {
 }
 
 func (bm *Bitmap) NewIterator() *Iterator {
+	return bm.NewIteratorDim(0)
+}
+
+// NewIteratorDim returns an iterator that yields only the values stored under the given dimension.
+// In a dim-aware bitmap each value is keyed by (value & mask) | uint64(dim), so iterators for
+// different dimensions are independent and return the same logical values in ascending order.
+// Call Next() repeatedly until it returns 0, which signals exhaustion.
+// Use NewIterator() to iterate over dim 0.
+func (bm *Bitmap) NewIteratorDim(dim uint16) *Iterator {
 	return &Iterator{
 		bm:        bm,
 		keys:      bm.keys[indexNodeStart : indexNodeStart+bm.keys.numKeys()*2],
 		keyIdx:    0,
+		dim:       dim,
 		contIdx:   -1,
 		bitmapIdx: -1,
 	}
 }
 
+// advanceToDim advances keyIdx until it finds a key matching it.dim.
+// Returns false if no such key exists.
+func (it *Iterator) advanceToDim() bool {
+	for uint16(it.keys[it.keyIdx]) != it.dim {
+		if it.keyIdx+2 >= len(it.keys) {
+			return false
+		}
+		// jump by 2 because key is followed by a value
+		it.keyIdx += 2
+	}
+	return true
+}
+
 func (it *Iterator) Next() uint64 {
-	if len(it.keys) == 0 {
+	if len(it.keys) == 0 || !it.advanceToDim() {
 		return 0
 	}
 
-	key := it.keys[it.keyIdx]
 	off := it.keys[it.keyIdx+1]
 	cont := it.bm.getContainer(off)
 	card := getCardinality(cont)
 
-	// Loop until we find a container on which next operation is possible. When such a container
-	// is found, reset the variables responsible for container iteration.
+	// Advance past empty or exhausted containers.
 	for card == 0 || it.contIdx+1 >= card {
 		if it.keyIdx+2 >= len(it.keys) {
 			return 0
 		}
-		// jump by 2 because key is followed by a value
 		it.keyIdx += 2
 		it.contIdx = -1
 		it.bitmapIdx = -1
 		it.bitset = 0
-		key = it.keys[it.keyIdx]
+		if !it.advanceToDim() {
+			return 0
+		}
 		off = it.keys[it.keyIdx+1]
 		cont = it.bm.getContainer(off)
 		card = getCardinality(cont)
 	}
 
-	//  The above loop assures that we can do next in this container.
+	key := it.keys[it.keyIdx] & mask
 	it.contIdx++
 	switch cont[indexType] {
 	case typeArray:
 		return key | uint64(cont[int(startIdx)+it.contIdx])
 	case typeBitmap:
-		// A bitmap container is an array of uint16s.
-		// If the container is bitmap, go to the index which has a non-zero value.
+		// A bitmap container is an array of uint16s; advance to the next non-zero word.
 		for it.bitset == 0 && it.bitmapIdx+1 < len(cont[startIdx:]) {
 			it.bitmapIdx++
 			it.bitset = cont[int(startIdx)+it.bitmapIdx]
 		}
 		assert(it.bitset > 0)
 
-		// msbIdx is the index of most-significant bit. In this iteration we choose this set bit
-		// and make it zero.
+		// Pick the most-significant set bit, then clear it.
 		msbIdx := uint16(bits.LeadingZeros16(it.bitset))
 		msb := 1 << (16 - msbIdx - 1)
 		it.bitset ^= uint16(msb)

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -18,6 +18,7 @@ package sroar
 
 import (
 	"math/rand"
+	"slices"
 	"sort"
 	"testing"
 
@@ -137,5 +138,229 @@ func BenchmarkIterator(b *testing.B) {
 		it := bm.NewIterator()
 		for it.Next() > 0 {
 		}
+	}
+}
+
+func TestIteratorBasicDims(t *testing.T) {
+	dims := uint16(3)
+	n := uint64(1e5)
+	bm := NewBitmap()
+
+	for x := uint64(1); x <= n; x++ {
+		for dim := uint16(0); dim < dims; dim++ {
+			bm.SetDim(x, dim)
+		}
+	}
+
+	iterators := make([]*Iterator, dims)
+	for dim := uint16(0); dim < dims; dim++ {
+		iterators[dim] = bm.NewIteratorDim(dim)
+	}
+
+	for x := uint64(1); x <= n; x++ {
+		for dim := uint16(0); dim < dims; dim++ {
+			xx := iterators[dim].Next()
+			require.Equal(t, x, xx)
+		}
+	}
+
+	for dim := uint16(0); dim < dims; dim++ {
+		xx := iterators[dim].Next()
+		require.Equal(t, uint64(0), xx)
+	}
+}
+
+func TestIteratorRandomDims(t *testing.T) {
+	dims := uint16(3)
+	n := uint64(1e6)
+	bm := NewBitmap()
+	mp := make(map[uint64]struct{})
+	var arr []uint64
+	for i := uint64(1); i <= n; i++ {
+		x := uint64(rand.Intn(int(n) * 5))
+		if x == 0 {
+			continue
+		}
+		if _, ok := mp[x]; ok {
+			continue
+		}
+		mp[x] = struct{}{}
+		arr = append(arr, x)
+		for dim := uint16(0); dim < dims; dim++ {
+			bm.SetDim(x, dim)
+		}
+	}
+
+	slices.Sort(arr)
+
+	iterators := make([]*Iterator, dims)
+	xx := make([]uint64, dims)
+	for dim := uint16(0); dim < dims; dim++ {
+		iterators[dim] = bm.NewIterator()
+		xx[dim] = iterators[dim].Next()
+	}
+	for i := uint64(0); i < uint64(len(arr)); i++ {
+		for dim := uint16(0); dim < dims; dim++ {
+			require.Equal(t, arr[i], xx[dim])
+			xx[dim] = iterators[dim].Next()
+		}
+	}
+}
+
+func TestIteratorDim(t *testing.T) {
+	t.Run("empty bitmap", func(t *testing.T) {
+		bm := NewBitmap()
+		require.Equal(t, uint64(0), bm.NewIteratorDim(0).Next())
+		require.Equal(t, uint64(0), bm.NewIteratorDim(5).Next())
+	})
+
+	t.Run("absent dim", func(t *testing.T) {
+		// Bitmap has values for dims 0 and 1, but not 2.
+		bm := NewBitmap()
+		for x := uint64(1); x <= 100; x++ {
+			bm.SetDim(x, 0)
+			bm.SetDim(x, 1)
+		}
+
+		require.Equal(t, uint64(0), bm.NewIteratorDim(2).Next())
+	})
+
+	t.Run("single value", func(t *testing.T) {
+		bm := NewBitmap()
+		bm.SetDim(42, 3)
+
+		it := bm.NewIteratorDim(3)
+		require.Equal(t, uint64(42), it.Next())
+		require.Equal(t, uint64(0), it.Next())
+	})
+
+	t.Run("exhaustion is idempotent", func(t *testing.T) {
+		bm := NewBitmap()
+		bm.SetDim(1, 0)
+		bm.SetDim(2, 0)
+
+		it := bm.NewIteratorDim(0)
+		require.Equal(t, uint64(1), it.Next())
+		require.Equal(t, uint64(2), it.Next())
+		require.Equal(t, uint64(0), it.Next())
+		require.Equal(t, uint64(0), it.Next())
+		require.Equal(t, uint64(0), it.Next())
+	})
+
+	t.Run("large dim value (max uint16)", func(t *testing.T) {
+		bm := NewBitmap()
+		dim := uint16(65535)
+		vals := []uint64{1, 100, 1000}
+		for _, v := range vals {
+			bm.SetDim(v, dim)
+			bm.SetDim(v, 0) // noise in another dim to confirm filtering
+		}
+
+		it := bm.NewIteratorDim(dim)
+		for _, exp := range vals {
+			require.Equal(t, exp, it.Next())
+		}
+		require.Equal(t, uint64(0), it.Next())
+	})
+
+	t.Run("partial overlap between dims", func(t *testing.T) {
+		// dim 0: 5, 10, 15, 20, 25, 30
+		// dim 1: 7, 10, 17, 20, 27, 30
+		bm := NewBitmap()
+		for _, x := range []uint64{5, 15, 25} {
+			bm.SetDim(x, 0)
+		}
+		for _, x := range []uint64{7, 17, 27} {
+			bm.SetDim(x, 1)
+		}
+		for _, x := range []uint64{10, 20, 30} {
+			bm.SetDim(x, 0)
+			bm.SetDim(x, 1)
+		}
+
+		it0 := bm.NewIteratorDim(0)
+		for _, exp := range []uint64{5, 10, 15, 20, 25, 30} {
+			require.Equal(t, exp, it0.Next())
+		}
+		require.Equal(t, uint64(0), it0.Next())
+
+		it1 := bm.NewIteratorDim(1)
+		for _, exp := range []uint64{7, 10, 17, 20, 27, 30} {
+			require.Equal(t, exp, it1.Next())
+		}
+		require.Equal(t, uint64(0), it1.Next())
+	})
+
+	t.Run("multiple containers", func(t *testing.T) {
+		// Each container covers a 65536-wide range; values here cross several boundaries.
+		bm := NewBitmap()
+		dim := uint16(2)
+		vals := []uint64{1, 65537, 131073, 196609}
+		for _, v := range vals {
+			bm.SetDim(v, dim)
+			bm.SetDim(v, 0) // noise in another dim to confirm filtering
+		}
+
+		it := bm.NewIteratorDim(dim)
+		for _, exp := range vals {
+			require.Equal(t, exp, it.Next())
+		}
+		require.Equal(t, uint64(0), it.Next())
+	})
+
+	t.Run("disjoint value sets per dim", func(t *testing.T) {
+		// dim 0: even numbers 2..20, dim 1: odd numbers 1..19
+		bm := NewBitmap()
+		for x := uint64(1); x <= 10; x++ {
+			bm.SetDim(x*2, 0)
+			bm.SetDim(x*2-1, 1)
+		}
+
+		it0 := bm.NewIteratorDim(0)
+		for x := uint64(1); x <= 10; x++ {
+			require.Equal(t, x*2, it0.Next())
+		}
+		require.Equal(t, uint64(0), it0.Next())
+
+		it1 := bm.NewIteratorDim(1)
+		for x := uint64(1); x <= 10; x++ {
+			require.Equal(t, x*2-1, it1.Next())
+		}
+		require.Equal(t, uint64(0), it1.Next())
+	})
+
+	t.Run("sorted order regardless of insertion order", func(t *testing.T) {
+		bm := NewBitmap()
+		for _, v := range []uint64{500, 300, 100, 400, 200} {
+			bm.SetDim(v, 1)
+		}
+
+		it := bm.NewIteratorDim(1)
+		for _, exp := range []uint64{100, 200, 300, 400, 500} {
+			require.Equal(t, exp, it.Next())
+		}
+		require.Equal(t, uint64(0), it.Next())
+	})
+}
+
+func TestIteratorWithRemoveKeysDims(t *testing.T) {
+	dims := uint16(3)
+	b := NewBitmap()
+	N := uint64(1e6)
+	for x := uint64(0); x < N; x++ {
+		for dim := uint16(0); dim < dims; dim++ {
+			b.SetDim(x, dim)
+		}
+	}
+
+	for dim := uint16(0); dim < dims; dim++ {
+		b.RemoveRangeDim(0, N, dim)
+		it := b.NewIteratorDim(dim)
+
+		cnt := 0
+		for it.Next() > 0 {
+			cnt++
+		}
+		require.Equal(t, 0, cnt)
 	}
 }

--- a/keys.go
+++ b/keys.go
@@ -196,7 +196,7 @@ func (n node) compact(lo uint64) int {
 
 // getValue returns the value corresponding to the key if found.
 func (n node) getValue(k uint64) (uint64, bool) {
-	k &= mask // Ensure k has its lowest bits unset.
+	// k &= mask // Ensure k has its lowest bits unset.
 	idx := n.search(k)
 	// key is not found
 	if idx >= n.numKeys() {


### PR DESCRIPTION
## Motivation

  Some callers need to tag each stored value with a 16-bit dimension (e.g. a vector index dimension or a shard ID) without maintaining a separate bitmap per dimension. Encoding the dimension directly in the lowest 16 bits of each key lets a single bitmap hold values across all dimensions while still supporting efficient per-dimension queries and iteration.

  ## Approach

  The key encoding is `(x & 0xFFFFFFFFFFFF0000) | uint64(dim)`, storing the 64-bit value in the upper 48 bits and the dimension in the lower 16. All existing methods (`Set`, `Contains`, `Remove`, etc.) implicitly use `dim=0`, so the encoding is fully backward-compatible.

  New `*Dim` methods accept an explicit `dim uint16` and operate only on containers whose key matches that dimension. `MergeDims()` collapses all dimensions into one by delegating to `maskedInto` with `mask=0xFFFFFFFFFFFF0000` — no new merge logic needed.
  `ToMapDims()` inverts the encoding, returning `map[uint64][]uint16` (value → list of dimensions). `NewIteratorDim` filters iteration to a single dimension by skipping containers at the key level.

  `AndMasked` / `AndMaskedConc` are updated to handle dim-aware destination bitmaps: containers with `dim != 0` (low 16 bits non-zero) are left untouched — they are neither ANDed nor zeroed. Only `dim=0` containers participate in the AND. This preserves the monotonic scan invariant in `andMaskedContainersInRange` without any additional overhead for non-dim-aware bitmaps.

  ## Key areas for review

  - `bitmap.go:SetDim` — key encoding: `(x & 0xFFFFFFFFFFFF0000) | uint64(dim)`; values with non-zero low 16 bits have those bits silently masked before encoding, consistent with plain `Set`
  - `bitmap.go:MergeDims` — delegates to `maskedInto(0xFFFFFFFFFFFF0000, ...)`; correctness depends on the mask matching the key encoding exactly
  - `bitmap_opt.go:andMaskedContainersInRange` — `uint16(ak) != 0` guard skips dim!=0 containers without advancing the `from` pointer, keeping the monotonic scan valid for dim=0 keys
  - `iterator.go:NewIteratorDim` — skips at the container (key) level, not the value level; entire containers for non-matching dims are jumped over

  ## Risks and mitigations

  - **Silent truncation of low 16 bits in SetDim**: values with non-zero low bits are stored correctly under the given dim; the low bits of `x` are masked away as they would conflict with the dim encoding. Documented on the method.
  - **AndMasked on dim-aware ra**: previously silently zeroed all dim!=0 containers (bug). Fixed by skipping them entirely. Callers relying on the old (broken) zeroing behaviour would need updating, but since dim support is new there are no such callers.

  ## Testing

  `*Dim` method tests cover round-trip Set/Contains/Remove, `RemoveRangeDim`, `GetCardinalityDim`, `ToArrayDim`, `ToMapDims`, `MergeDims` (verified against equivalent `Masked()` call), `FromSortedListDim`, and `NewIteratorDim` across mixed-dimension bitmaps.
  `TestAndMaskedDimAware` confirms the fix: dim=1 containers in ra survive `AndMasked` / `AndMaskedConc` when b has a matching value at dim=0.