### PR TITLE
feature: fused mask+AND operations — MaskedAnd, AndMasked, AndMaskedConc

### DIFF
--- a/bitmap_opt.go
+++ b/bitmap_opt.go
@@ -1188,6 +1188,45 @@ func (ra *Bitmap) MaskedToBuf(mask uint64, buf []byte) *Bitmap {
 	return ra.maskedInto(mask, NewBitmapToBuf(buf))
 }
 
+// writeToMaskedResult writes src into res under maskedKey, OR-merging with
+// any existing container for that key. orBuf is a scratch buffer for the OR
+// operation when inline merge fails (container grew beyond current allocation).
+func writeToMaskedResult(res *Bitmap, maskedKey uint64, src, orBuf []uint16) {
+	off, has := res.keys.getValue(maskedKey)
+	if !has {
+		// First container for this masked key — copy it directly.
+		res.expandConditionally(0, len(src))
+		off = res.newContainerNoClr(uint16(len(src)))
+		copy(res.data[off:], src)
+		res.setKey(maskedKey, off)
+	} else {
+		// Merge with the existing container via OR.
+		existing := res.getContainer(off)
+		if c := containerOrAlt(existing, src, orBuf, runInline); len(c) > 0 {
+			// Inline failed (container grew). If the old container
+			// is at the end of res.data, trim and regrow in place to
+			// avoid dead space. Otherwise append (dead space).
+			if off+uint64(len(existing)) == uint64(len(res.data)) {
+				res.data = res.data[:off]
+			}
+			res.expandConditionally(0, len(c))
+			off = res.newContainerNoClr(uint16(len(c)))
+			copy(res.data[off:], c)
+			res.setKey(maskedKey, off)
+		}
+	}
+}
+
+// maskedInto is the core implementation of Masked and MaskedToBuf.
+//
+// Alternative approach was considered and benchmarked: sort source keys by
+// masked value upfront, count distinct masked keys for exact key pre-allocation,
+// accumulate OR per group in scratch buffers, then write each group's final
+// container once — eliminating getValue binary searches, setKey shifts, and
+// dead-space risk. In practice this was not faster: the extra allocations
+// (maskedEntry slice + two scratch buffers vs one) and the sort cost outweigh
+// the savings from avoiding binary searches and in-place OR. Memory consumption
+// was also higher in most cases. Current approach wins.
 func (ra *Bitmap) maskedInto(mask uint64, b *Bitmap) *Bitmap {
 	if ra == nil {
 		return b
@@ -1215,30 +1254,7 @@ func (ra *Bitmap) maskedInto(mask uint64, b *Bitmap) *Bitmap {
 		}
 
 		maskedKey := ak & mask
-
-		boff, has := b.keys.getValue(maskedKey)
-		if !has {
-			// First container for this masked key — copy it directly.
-			b.expandConditionally(0, len(ac))
-			boff = b.newContainerNoClr(uint16(len(ac)))
-			copy(b.data[boff:], ac)
-			b.setKey(maskedKey, boff)
-		} else {
-			// Merge with the existing container via OR.
-			bc := b.getContainer(boff)
-			if c := containerOrAlt(bc, ac, buf, runInline); len(c) > 0 {
-				// Inline failed (container grew). If the old container
-				// is at the end of b.data, trim and regrow in place to
-				// avoid dead space. Otherwise append (dead space).
-				if boff+uint64(len(bc)) == uint64(len(b.data)) {
-					b.data = b.data[:boff]
-				}
-				b.expandConditionally(0, len(c))
-				boff = b.newContainerNoClr(uint16(len(c)))
-				copy(b.data[boff:], c)
-				b.setKey(maskedKey, boff)
-			}
-		}
+		writeToMaskedResult(b, maskedKey, ac, buf)
 	}
 	return b
 }
@@ -1273,6 +1289,11 @@ func maskedAndInto(a, b *Bitmap, mask uint64, res *Bitmap) *Bitmap {
 	minKeys := min(an, bn)
 	res.expandConditionally(minKeys, 0)
 
+	// Only the larger side can trigger galloping — the smaller side can never
+	// satisfy candidate > threshold*8, so exactly one flag can be true.
+	useGallopA := shouldGallop(an, bn)
+	useGallopB := shouldGallop(bn, an)
+
 	// andBuf holds the AND result for one container pair.
 	// orBuf is the scratch for merging into res when masked keys collide.
 	// They must be separate since andBuf is the OR source.
@@ -1290,37 +1311,22 @@ func maskedAndInto(a, b *Bitmap, mask uint64, res *Bitmap) *Bitmap {
 			c := containerAndAlt(ac, bc, andBuf, 0)
 			if len(c) > 0 && getCardinality(c) > 0 {
 				maskedKey := ak & mask
-
-				roff, has := res.keys.getValue(maskedKey)
-				if !has {
-					// First container for this masked key — copy it directly.
-					res.expandConditionally(0, len(c))
-					roff = res.newContainerNoClr(uint16(len(c)))
-					copy(res.data[roff:], c)
-					res.setKey(maskedKey, roff)
-				} else {
-					// Merge with the existing container via OR.
-					rc := res.getContainer(roff)
-					if out := containerOrAlt(rc, c, orBuf, runInline); len(out) > 0 {
-						// Inline failed (container grew). If the old container
-						// is at the end of res.data, trim and regrow in place to
-						// avoid dead space. Otherwise append (dead space).
-						if roff+uint64(len(rc)) == uint64(len(res.data)) {
-							res.data = res.data[:roff]
-						}
-						res.expandConditionally(0, len(out))
-						roff = res.newContainerNoClr(uint16(len(out)))
-						copy(res.data[roff:], out)
-						res.setKey(maskedKey, roff)
-					}
-				}
+				writeToMaskedResult(res, maskedKey, c, orBuf)
 			}
 			ai++
 			bi++
 		} else if ak < bk {
-			ai++
+			if useGallopA {
+				ai = a.keys.searchFrom(ai, bk)
+			} else {
+				ai++
+			}
 		} else {
-			bi++
+			if useGallopB {
+				bi = b.keys.searchFrom(bi, ak)
+			} else {
+				bi++
+			}
 		}
 	}
 	return res
@@ -1469,8 +1475,9 @@ func andMaskedContainersInRange(ra, b *Bitmap, entries []maskedEntry, ai, aj int
 			}
 		}
 
-		// AND ra's container with the OR result, in place. AND can only
-		// shrink a container so inline always succeeds.
+		// AND ra's container with the OR result, in place. AND keeps the
+		// container size unchanged (only the number of elements decreases),
+		// so inline always succeeds.
 		if c := containerAndAlt(ac, orResult, nil, runInline); len(c) > 0 {
 			panic("new container not expected in AndMasked inline mode")
 		}

--- a/bitmap_opt.go
+++ b/bitmap_opt.go
@@ -1325,3 +1325,154 @@ func maskedAndInto(a, b *Bitmap, mask uint64, res *Bitmap) *Bitmap {
 	}
 	return res
 }
+
+// maskedEntry pairs a bitmap container's offset with the masked value of its key.
+type maskedEntry struct{ maskedKey, offset uint64 }
+
+// buildMaskedEntries returns a sorted slice of maskedEntry for bm, with each
+// key masked by mask. The result is sorted by maskedKey for binary search.
+func buildMaskedEntries(bm *Bitmap, mask uint64) []maskedEntry {
+	n := bm.keys.numKeys()
+	entries := make([]maskedEntry, n)
+	for i := 0; i < n; i++ {
+		entries[i] = maskedEntry{
+			maskedKey: bm.keys.key(i) & mask,
+			offset:    bm.keys.val(i),
+		}
+	}
+	slices.SortFunc(entries, func(a, b maskedEntry) int {
+		if a.maskedKey < b.maskedKey {
+			return -1
+		}
+		if a.maskedKey > b.maskedKey {
+			return 1
+		}
+		return 0
+	})
+	return entries
+}
+
+// maskedEntriesFor returns the subslice of entries whose maskedKey equals key
+// and the position to pass as from on the next call, or nil if no match exists.
+// from is a hint: the caller passes back the value returned by the previous
+// call, allowing a linear scan across a sorted sequence of keys instead of a
+// binary search on every call.
+// entries must be sorted by maskedKey, and successive calls must use
+// non-decreasing key values.
+func maskedEntriesFor(entries []maskedEntry, key uint64, from int) ([]maskedEntry, int) {
+	for from < len(entries) && entries[from].maskedKey < key {
+		from++
+	}
+	if from >= len(entries) || entries[from].maskedKey != key {
+		return nil, from
+	}
+	lo := from
+	hi := lo + 1
+	for hi < len(entries) && entries[hi].maskedKey == key {
+		hi++
+	}
+	return entries[lo:hi], hi
+}
+
+// AndMasked is equivalent to ra.And(b.Masked(mask)) but avoids allocating
+// an intermediate masked bitmap. b is not modified.
+//
+// For each key k in ra, AndMasked finds all keys k' in b where k'&mask == k,
+// ORs their containers together, then ANDs the result into ra's container at k.
+// If no key in b maps to k under the mask, ra's container at k is zeroed out.
+// The lowest 16 bits of the mask are always ignored.
+func (ra *Bitmap) AndMasked(b *Bitmap, mask uint64) *Bitmap {
+	if b.IsEmpty() {
+		ra.ZeroOut()
+		return ra
+	}
+
+	mask &= 0xFFFFFFFFFFFF0000
+	entries := buildMaskedEntries(b, mask)
+	andMaskedContainersInRange(ra, b, entries, 0, ra.keys.numKeys())
+	return ra
+}
+
+// AndMaskedConc is like AndMasked but processes ra's containers concurrently.
+// Concurrency is calculated based on number of internal containers in ra, so
+// that each goroutine handles at least [minContainersPerRoutine] containers.
+// maxConcurrency limits concurrency calculated internally.
+// If maxConcurrency <= 0, then calculated concurrency is not limited.
+func (ra *Bitmap) AndMaskedConc(b *Bitmap, mask uint64, maxConcurrency int) *Bitmap {
+	if b.IsEmpty() {
+		ra.ZeroOut()
+		return ra
+	}
+
+	mask &= 0xFFFFFFFFFFFF0000
+
+	// Build entries once; goroutines only read from it.
+	entries := buildMaskedEntries(b, mask)
+
+	an := ra.keys.numKeys()
+	concurrency := calcConcurrency(an, minContainersPerRoutine, maxConcurrency)
+	callback := func(ai, aj, _ int) { andMaskedContainersInRange(ra, b, entries, ai, aj) }
+	concurrentlyInRanges(an, concurrency, callback)
+	return ra
+}
+
+func andMaskedContainersInRange(ra, b *Bitmap, entries []maskedEntry, ai, aj int) {
+	// orBuf holds the accumulated OR result across the group.
+	// fallbackBuf is needed only when inline OR fails (array+array that must
+	// convert to bitmap): the result lands in fallbackBuf, which is then swapped
+	// with orBuf so subsequent iterations continue to use orBuf as the target.
+	orBuf := make([]uint16, maxContainerSize)
+	fallbackBuf := make([]uint16, maxContainerSize)
+
+	// Binary search to find the starting position in entries for this range.
+	// The two-pointer optimisation used in the sequential path is not applicable
+	// here since each goroutine starts at an arbitrary key.
+	from, _ := slices.BinarySearchFunc(entries, ra.keys.key(ai), func(e maskedEntry, k uint64) int {
+		if e.maskedKey < k {
+			return -1
+		}
+		if e.maskedKey > k {
+			return 1
+		}
+		return 0
+	})
+
+	for ; ai < aj; ai++ {
+		ak := ra.keys.key(ai)
+		ac := ra.getContainer(ra.keys.val(ai))
+
+		var group []maskedEntry
+		group, from = maskedEntriesFor(entries, ak, from)
+		if group == nil {
+			// No b key maps to ak under the mask — zero out ra's container.
+			zeroOutContainer(ac)
+			continue
+		}
+
+		// Build the OR of all b containers in the group.
+		var orResult []uint16
+		if len(group) == 1 {
+			// Single container — use directly, no OR needed.
+			orResult = b.getContainer(group[0].offset)
+		} else {
+			// Copy the first container into orBuf so we can OR into it in place.
+			copy(orBuf, b.getContainer(group[0].offset))
+			orResult = orBuf
+
+			for i := 1; i < len(group); i++ {
+				if c := containerOrAlt(orResult, b.getContainer(group[i].offset), fallbackBuf, runInline); len(c) > 0 {
+					// Inline failed (array→bitmap conversion): result is in fallbackBuf.
+					// Swap so orBuf always holds the current result.
+					orBuf, fallbackBuf = fallbackBuf, orBuf
+					orResult = c
+				}
+			}
+		}
+
+		// AND ra's container with the OR result, in place. AND can only
+		// shrink a container so inline always succeeds.
+		if c := containerAndAlt(ac, orResult, nil, runInline); len(c) > 0 {
+			panic("new container not expected in AndMasked inline mode")
+		}
+	}
+}

--- a/bitmap_opt.go
+++ b/bitmap_opt.go
@@ -1242,3 +1242,86 @@ func (ra *Bitmap) maskedInto(mask uint64, b *Bitmap) *Bitmap {
 	}
 	return b
 }
+
+// MaskedAnd returns a new bitmap containing the AND of a and b, with mask
+// applied to all keys. Keys that become equal after masking have their
+// containers merged via OR. This is equivalent to Masked(And(a, b), mask)
+// but allocates only one bitmap instead of two. Neither a nor b is modified.
+// The lowest 16 bits of keys are always zeroed.
+func MaskedAnd(a, b *Bitmap, mask uint64) *Bitmap {
+	return maskedAndInto(a, b, mask, NewBitmap())
+}
+
+// MaskedAndToBuf is like MaskedAnd but uses the provided byte slice as the
+// underlying buffer for the result bitmap, avoiding heap allocation when
+// the buffer is large enough. The lowest 16 bits of keys are always zeroed.
+func MaskedAndToBuf(a, b *Bitmap, mask uint64, buf []byte) *Bitmap {
+	return maskedAndInto(a, b, mask, NewBitmapToBuf(buf))
+}
+
+func maskedAndInto(a, b *Bitmap, mask uint64, res *Bitmap) *Bitmap {
+	if a.IsEmpty() || b.IsEmpty() {
+		return res
+	}
+
+	mask &= 0xFFFFFFFFFFFF0000
+
+	ai, an := 0, a.keys.numKeys()
+	bi, bn := 0, b.keys.numKeys()
+
+	// AND can produce at most min(an, bn) distinct keys before masking.
+	minKeys := min(an, bn)
+	res.expandConditionally(minKeys, 0)
+
+	// andBuf holds the AND result for one container pair.
+	// orBuf is the scratch for merging into res when masked keys collide.
+	// They must be separate since andBuf is the OR source.
+	andBuf := make([]uint16, maxContainerSize)
+	orBuf := make([]uint16, maxContainerSize)
+
+	for ai < an && bi < bn {
+		ak := a.keys.key(ai)
+		bk := b.keys.key(bi)
+
+		if ak == bk {
+			ac := a.getContainer(a.keys.val(ai))
+			bc := b.getContainer(b.keys.val(bi))
+
+			c := containerAndAlt(ac, bc, andBuf, 0)
+			if len(c) > 0 && getCardinality(c) > 0 {
+				maskedKey := ak & mask
+
+				roff, has := res.keys.getValue(maskedKey)
+				if !has {
+					// First container for this masked key — copy it directly.
+					res.expandConditionally(0, len(c))
+					roff = res.newContainerNoClr(uint16(len(c)))
+					copy(res.data[roff:], c)
+					res.setKey(maskedKey, roff)
+				} else {
+					// Merge with the existing container via OR.
+					rc := res.getContainer(roff)
+					if out := containerOrAlt(rc, c, orBuf, runInline); len(out) > 0 {
+						// Inline failed (container grew). If the old container
+						// is at the end of res.data, trim and regrow in place to
+						// avoid dead space. Otherwise append (dead space).
+						if roff+uint64(len(rc)) == uint64(len(res.data)) {
+							res.data = res.data[:roff]
+						}
+						res.expandConditionally(0, len(out))
+						roff = res.newContainerNoClr(uint16(len(out)))
+						copy(res.data[roff:], out)
+						res.setKey(maskedKey, roff)
+					}
+				}
+			}
+			ai++
+			bi++
+		} else if ak < bk {
+			ai++
+		} else {
+			bi++
+		}
+	}
+	return res
+}

--- a/bitmap_opt_test.go
+++ b/bitmap_opt_test.go
@@ -2884,3 +2884,441 @@ func TestMaskedAndToBuf(t *testing.T) {
 		require.Equal(t, bufSize, result.capInBytes(), "capacity should not change")
 	})
 }
+
+func TestAndMasked(t *testing.T) {
+	t.Run("empty b zeroes ra", func(t *testing.T) {
+		ra := NewBitmap()
+		ra.Set(1)
+		ra.Set(2)
+		ra.AndMasked(NewBitmap(), math.MaxUint64)
+		require.Equal(t, 0, ra.GetCardinality())
+	})
+
+	t.Run("nil b zeroes ra", func(t *testing.T) {
+		ra := NewBitmap()
+		ra.Set(1)
+		var b *Bitmap
+		ra.AndMasked(b, math.MaxUint64)
+		require.Equal(t, 0, ra.GetCardinality())
+	})
+
+	t.Run("identity mask matches ra.And(b)", func(t *testing.T) {
+		for _, mask := range []uint64{math.MaxUint64, math.MaxUint64 | 0xFFFF} {
+			ra := NewBitmap()
+			b := NewBitmap()
+			for i := uint64(0); i < 200; i++ {
+				ra.Set(i)
+				if i%2 == 0 {
+					b.Set(i)
+				}
+			}
+
+			expected := ra.Clone()
+			expected.And(b)
+
+			ra.AndMasked(b, mask)
+
+			require.Equal(t, expected.GetCardinality(), ra.GetCardinality(), "mask %#x", mask)
+			for _, v := range expected.ToArray() {
+				require.True(t, ra.Contains(v), "mask %#x missing %d", mask, v)
+			}
+		}
+	})
+
+	t.Run("matches ra.Clone().And(b.Masked(mask))", func(t *testing.T) {
+		masks := []uint64{0, 0x0000FFFFFFFFFFFF, math.MaxUint64, 0x00000000FFFF0000}
+
+		b := NewBitmap()
+		for pos := uint64(0); pos < 5; pos++ {
+			for v := uint64(0); v < 100; v++ {
+				b.Set(pos<<48 | v)
+			}
+		}
+
+		for _, mask := range masks {
+			ra := NewBitmap()
+			for pos := uint64(0); pos < 3; pos++ {
+				for v := uint64(0); v < 100; v++ {
+					ra.Set(pos<<48 | v)
+				}
+			}
+
+			expected := ra.Clone()
+			expected.And(b.Masked(mask))
+
+			ra.AndMasked(b, mask)
+
+			require.Equal(t, expected.GetCardinality(), ra.GetCardinality(), "mask %#x", mask)
+			for _, v := range expected.ToArray() {
+				require.True(t, ra.Contains(v), "mask %#x missing %d", mask, v)
+			}
+		}
+	})
+
+	t.Run("zero mask collapses all b keys to zero", func(t *testing.T) {
+		ra := NewBitmap()
+		ra.Set(0x00000000 | 1) // key 0, value 1
+		ra.Set(0x00000000 | 2) // key 0, value 2
+		ra.Set(0x00010000 | 3) // key 1, value 3 — no b key maps here under zero mask
+
+		b := NewBitmap()
+		b.Set(0x00010000 | 1) // key 1 → masked 0, value 1
+		b.Set(0x00020000 | 2) // key 2 → masked 0, value 2
+
+		// Masked(b) at key 0 = OR({1}, {2}) = {1, 2}
+		// ra[key 0] AND {1, 2} = {1, 2} AND {1, 2} = {1, 2}
+		// ra[key 1] has no match → zeroed
+		ra.AndMasked(b, 0)
+
+		require.Equal(t, 2, ra.GetCardinality())
+		require.True(t, ra.Contains(1))
+		require.True(t, ra.Contains(2))
+		require.False(t, ra.Contains(0x00010000|3))
+	})
+
+	t.Run("b not modified", func(t *testing.T) {
+		ra := NewBitmap()
+		b := NewBitmap()
+		for i := uint64(0); i < 100; i++ {
+			ra.Set(i)
+			b.Set(uint64(1)<<48 | i)
+		}
+		bCard := b.GetCardinality()
+		bValues := b.ToArray()
+
+		ra.AndMasked(b, 0x0000FFFFFFFFFFFF)
+
+		require.Equal(t, bCard, b.GetCardinality())
+		for _, v := range bValues {
+			require.True(t, b.Contains(v))
+		}
+	})
+
+	t.Run("multiple b keys OR before AND", func(t *testing.T) {
+		ra := NewBitmap()
+		// key 0: values {0, 1, 2, 3}
+		for v := uint64(0); v <= 3; v++ {
+			ra.Set(v)
+		}
+
+		b := NewBitmap()
+		// Two b keys both masked to 0: first has {1,2}, second has {3,4}
+		// OR = {1,2,3,4}; AND with ra[key 0]={0,1,2,3} = {1,2,3}
+		b.Set(0x00010000 | 1)
+		b.Set(0x00010000 | 2)
+		b.Set(0x00020000 | 3)
+		b.Set(0x00020000 | 4)
+
+		ra.AndMasked(b, 0)
+
+		require.Equal(t, 3, ra.GetCardinality())
+		require.True(t, ra.Contains(1))
+		require.True(t, ra.Contains(2))
+		require.True(t, ra.Contains(3))
+		require.False(t, ra.Contains(0))
+		require.False(t, ra.Contains(4))
+	})
+
+	// The next four tests target the buffer-swap logic in the OR accumulation loop.
+	// The source container (orBuf) is always exactly-sized after copying group[0],
+	// so any non-overlapping element OR'd in will not fit inline — the result
+	// lands in fallbackBuf and the two buffers are swapped.
+
+	t.Run("non-overlapping arrays: inline fails due to size, buffers swapped", func(t *testing.T) {
+		// group[0] has 50 elements → orBuf.indexSize = 54 (4 header + 50 values).
+		// group[1] adds 50 non-overlapping elements → result needs indexSize 104.
+		// 54 < 104 → inline fails, result is in fallbackBuf, swap occurs.
+		ra := NewBitmap()
+		for v := uint64(0); v < 100; v++ {
+			ra.Set(v)
+		}
+
+		b := NewBitmap()
+		for v := uint64(0); v < 50; v++ {
+			b.Set(0x00010000 | v) // key 1 → masked 0, values 0-49
+		}
+		for v := uint64(50); v < 100; v++ {
+			b.Set(0x00020000 | v) // key 2 → masked 0, values 50-99
+		}
+
+		ra.AndMasked(b, 0)
+
+		require.Equal(t, 100, ra.GetCardinality())
+		for v := uint64(0); v < 100; v++ {
+			require.True(t, ra.Contains(v))
+		}
+	})
+
+	t.Run("overlapping arrays: inline succeeds, no swap", func(t *testing.T) {
+		// group[0] and group[1] have identical values → OR result cardinality
+		// equals group[0] cardinality → fits within orBuf.indexSize → no swap.
+		ra := NewBitmap()
+		for v := uint64(0); v < 50; v++ {
+			ra.Set(v)
+		}
+
+		b := NewBitmap()
+		for v := uint64(0); v < 50; v++ {
+			b.Set(0x00010000 | v) // key 1 → masked 0, values 0-49
+		}
+		for v := uint64(0); v < 50; v++ {
+			b.Set(0x00020000 | v) // key 2 → masked 0, same values 0-49
+		}
+
+		ra.AndMasked(b, 0)
+
+		require.Equal(t, 50, ra.GetCardinality())
+		for v := uint64(0); v < 50; v++ {
+			require.True(t, ra.Contains(v))
+		}
+	})
+
+	t.Run("large non-overlapping arrays: bitmap conversion triggers swap", func(t *testing.T) {
+		// cnum + onum = 1228 + 1228 = 2456 >= 2456 → array-to-bitmap conversion.
+		// Source container has indexSize = 1232 < maxContainerSize → inline fails,
+		// result (bitmap) lands in fallbackBuf, buffers are swapped.
+		const half = 1228 // cnum + onum == 2456 == maxContainerSize/5*3 - startIdx
+
+		ra := NewBitmap()
+		for v := uint64(0); v < 2*half; v++ {
+			ra.Set(v)
+		}
+
+		b := NewBitmap()
+		for v := uint64(0); v < half; v++ {
+			b.Set(0x00010000 | v) // key 1 → masked 0, values 0-1227
+		}
+		for v := uint64(half); v < 2*half; v++ {
+			b.Set(0x00020000 | v) // key 2 → masked 0, values 1228-2455
+		}
+
+		ra.AndMasked(b, 0)
+
+		require.Equal(t, 2*half, ra.GetCardinality())
+		for v := uint64(0); v < 2*half; v++ {
+			require.True(t, ra.Contains(v))
+		}
+	})
+
+	t.Run("three containers: swap on first pair, then OR into bitmap succeeds inline", func(t *testing.T) {
+		// First OR triggers bitmap conversion and swap (result now in orBuf as bitmap).
+		// Second OR is bitmap+array: inline always succeeds, fallbackBuf unused.
+		// Verifies that orResult correctly points into orBuf after the swap.
+		const half = 1228
+
+		ra := NewBitmap()
+		for v := uint64(0); v < 3*half; v++ {
+			ra.Set(v)
+		}
+
+		b := NewBitmap()
+		for v := uint64(0); v < half; v++ {
+			b.Set(0x00010000 | v) // key 1 → masked 0
+		}
+		for v := uint64(half); v < 2*half; v++ {
+			b.Set(0x00020000 | v) // key 2 → masked 0, triggers swap with key 1
+		}
+		for v := uint64(2*half); v < 3*half; v++ {
+			b.Set(0x00030000 | v) // key 3 → masked 0, OR'd into bitmap inline
+		}
+
+		ra.AndMasked(b, 0)
+
+		require.Equal(t, 3*half, ra.GetCardinality())
+		for v := uint64(0); v < 3*half; v++ {
+			require.True(t, ra.Contains(v))
+		}
+	})
+}
+
+func TestAndMaskedConc(t *testing.T) {
+	// n is large enough to guarantee at least 2 goroutines:
+	// calcConcurrency uses minContainersPerRoutine=24, so n >= 48 gives concurrency >= 2.
+	const n = minContainersPerRoutine * 3 // 72 keys
+
+	// mask keeps bits 16-31 and zeroes bits 32-63.
+	// b keys at (g<<32 | k<<16) all map to ra key (k<<16) under this mask.
+	const mask uint64 = 0x00000000FFFF0000
+
+	// assertMatchesSeq verifies that AndMaskedConc produces the same result as
+	// AndMasked at several concurrency levels, including one that forces
+	// actual goroutine spawning (maxConc=0 means unlimited).
+	assertMatchesSeq := func(t *testing.T, ra, b *Bitmap, m uint64) {
+		t.Helper()
+		expected := ra.Clone()
+		expected.AndMasked(b, m)
+		for _, maxConc := range []int{1, 2, 4, 0} {
+			got := ra.Clone()
+			got.AndMaskedConc(b, m, maxConc)
+			require.Equal(t, expected.GetCardinality(), got.GetCardinality(), "maxConc=%d", maxConc)
+			for _, v := range expected.ToArray() {
+				require.True(t, got.Contains(v), "maxConc=%d missing %d", maxConc, v)
+			}
+		}
+	}
+
+	t.Run("empty b zeroes ra", func(t *testing.T) {
+		ra := NewBitmap()
+		ra.Set(1)
+		ra.AndMaskedConc(NewBitmap(), math.MaxUint64, 0)
+		require.Equal(t, 0, ra.GetCardinality())
+	})
+
+	t.Run("nil b zeroes ra", func(t *testing.T) {
+		ra := NewBitmap()
+		ra.Set(1)
+		var b *Bitmap
+		ra.AndMaskedConc(b, math.MaxUint64, 0)
+		require.Equal(t, 0, ra.GetCardinality())
+	})
+
+	t.Run("identity mask", func(t *testing.T) {
+		// Mirror of TestAndMasked/identity_mask_matches_ra.And(b).
+		// n ra keys, b has same keys with even-valued elements only.
+		ra := NewBitmap()
+		b := NewBitmap()
+		for k := uint64(0); k < n; k++ {
+			for v := uint64(0); v < 200; v++ {
+				ra.Set(k<<16 | v)
+				if v%2 == 0 {
+					b.Set(k<<16 | v)
+				}
+			}
+		}
+		assertMatchesSeq(t, ra, b, math.MaxUint64)
+	})
+
+	t.Run("matches AndMasked across masks", func(t *testing.T) {
+		// Mirror of TestAndMasked/matches_ra.Clone().And(b.Masked(mask)).
+		// n ra keys; b spreads the same keys across 5 high-bit positions.
+		ra := NewBitmap()
+		b := NewBitmap()
+		for k := uint64(0); k < n; k++ {
+			for v := uint64(0); v < 100; v++ {
+				ra.Set(k<<16 | v)
+			}
+			for pos := uint64(0); pos < 5; pos++ {
+				for v := uint64(0); v < 100; v++ {
+					b.Set(pos<<32 | k<<16 | v)
+				}
+			}
+		}
+		for _, m := range []uint64{0, 0x0000FFFFFFFFFFFF, math.MaxUint64, mask} {
+			assertMatchesSeq(t, ra, b, m)
+		}
+	})
+
+	t.Run("zero mask: most ra containers zeroed out", func(t *testing.T) {
+		// Mirror of TestAndMasked/zero_mask_collapses_all_b_keys_to_zero.
+		// Under mask=0 only ra key 0 has a match; all others are zeroed.
+		// This exercises the zero-out path across n-1 containers concurrently.
+		ra := NewBitmap()
+		b := NewBitmap()
+		for k := uint64(0); k < n; k++ {
+			ra.Set(k<<16 | 1)
+			ra.Set(k<<16 | 2)
+		}
+		b.Set(0x00010000 | 1) // maps to masked key 0
+		b.Set(0x00020000 | 2) // maps to masked key 0
+		assertMatchesSeq(t, ra, b, 0)
+	})
+
+	t.Run("multiple b keys OR before AND", func(t *testing.T) {
+		// Mirror of TestAndMasked/multiple_b_keys_OR_before_AND.
+		// Each ra key has 2 b keys mapping to it; OR triggers buffer swap
+		// (non-overlapping arrays, result doesn't fit in source container).
+		ra := NewBitmap()
+		b := NewBitmap()
+		for k := uint64(0); k < n; k++ {
+			for v := uint64(0); v <= 3; v++ {
+				ra.Set(k<<16 | v)
+			}
+			b.Set(uint64(1)<<32 | k<<16 | 1)
+			b.Set(uint64(1)<<32 | k<<16 | 2)
+			b.Set(uint64(2)<<32 | k<<16 | 3)
+			b.Set(uint64(2)<<32 | k<<16 | 4)
+		}
+		assertMatchesSeq(t, ra, b, mask)
+	})
+
+	t.Run("overlapping arrays: inline OR succeeds without swap", func(t *testing.T) {
+		// Mirror of TestAndMasked/overlapping_arrays:_inline_succeeds,_no_swap.
+		// Two b keys per ra key with identical values — OR result fits in source.
+		ra := NewBitmap()
+		b := NewBitmap()
+		for k := uint64(0); k < n; k++ {
+			for v := uint64(0); v < 50; v++ {
+				ra.Set(k<<16 | v)
+				b.Set(uint64(1)<<32 | k<<16 | v)
+				b.Set(uint64(2)<<32 | k<<16 | v)
+			}
+		}
+		assertMatchesSeq(t, ra, b, mask)
+	})
+
+	t.Run("large non-overlapping arrays: bitmap conversion triggers swap", func(t *testing.T) {
+		// Mirror of TestAndMasked/large_non-overlapping_arrays.
+		// Per ra key: two b keys with 1228 non-overlapping values each →
+		// cnum+onum=2456 triggers array-to-bitmap conversion and buffer swap.
+		const half = 1228
+		ra := NewBitmap()
+		b := NewBitmap()
+		for k := uint64(0); k < n; k++ {
+			for v := uint64(0); v < 2*half; v++ {
+				ra.Set(k<<16 | v)
+			}
+			for v := uint64(0); v < half; v++ {
+				b.Set(uint64(1)<<32 | k<<16 | v)
+			}
+			for v := uint64(half); v < 2*half; v++ {
+				b.Set(uint64(2)<<32 | k<<16 | v)
+			}
+		}
+		assertMatchesSeq(t, ra, b, mask)
+	})
+
+	t.Run("three containers: swap then OR into bitmap", func(t *testing.T) {
+		// Mirror of TestAndMasked/three_containers:_swap_on_first_pair.
+		// Per ra key: first pair triggers bitmap conversion and swap;
+		// third container is OR'd inline into the resulting bitmap.
+		const half = 1228
+		ra := NewBitmap()
+		b := NewBitmap()
+		for k := uint64(0); k < n; k++ {
+			for v := uint64(0); v < 3*half; v++ {
+				ra.Set(k<<16 | v)
+			}
+			for v := uint64(0); v < half; v++ {
+				b.Set(uint64(1)<<32 | k<<16 | v)
+			}
+			for v := uint64(half); v < 2*half; v++ {
+				b.Set(uint64(2)<<32 | k<<16 | v)
+			}
+			for v := uint64(2*half); v < 3*half; v++ {
+				b.Set(uint64(3)<<32 | k<<16 | v)
+			}
+		}
+		assertMatchesSeq(t, ra, b, mask)
+	})
+
+	t.Run("b not modified", func(t *testing.T) {
+		ra := NewBitmap()
+		b := NewBitmap()
+		for k := uint64(0); k < n; k++ {
+			for v := uint64(0); v < 50; v++ {
+				ra.Set(k<<16 | v)
+				b.Set(uint64(1)<<32 | k<<16 | v)
+				b.Set(uint64(2)<<32 | k<<16 | v)
+			}
+		}
+		bCard := b.GetCardinality()
+		bValues := b.ToArray()
+
+		ra.AndMaskedConc(b, mask, 0)
+
+		require.Equal(t, bCard, b.GetCardinality())
+		for _, v := range bValues {
+			require.True(t, b.Contains(v))
+		}
+	})
+}

--- a/bitmap_opt_test.go
+++ b/bitmap_opt_test.go
@@ -2,6 +2,7 @@ package sroar
 
 import (
 	"fmt"
+	"math"
 	"math/bits"
 	"math/rand"
 	"slices"
@@ -2719,5 +2720,167 @@ func TestCalcConcurrency(t *testing.T) {
 
 	t.Run("maxConcurrency equal to calculated returns calculated", func(t *testing.T) {
 		require.Equal(t, 4, calcConcurrency(96, 24, 4))
+	})
+}
+
+func TestMaskedAnd(t *testing.T) {
+	t.Run("nil inputs", func(t *testing.T) {
+		var a, b *Bitmap
+		require.Equal(t, 0, MaskedAnd(a, b, math.MaxUint64).GetCardinality())
+		require.Equal(t, 0, MaskedAnd(NewBitmap(), b, math.MaxUint64).GetCardinality())
+		require.Equal(t, 0, MaskedAnd(a, NewBitmap(), math.MaxUint64).GetCardinality())
+	})
+
+	t.Run("empty inputs", func(t *testing.T) {
+		require.Equal(t, 0, MaskedAnd(NewBitmap(), NewBitmap(), math.MaxUint64).GetCardinality())
+	})
+
+	t.Run("no overlap produces empty result", func(t *testing.T) {
+		a := NewBitmap()
+		a.Set(0x00010000)
+		a.Set(0x00010001)
+
+		b := NewBitmap()
+		b.Set(0x00020000)
+		b.Set(0x00020001)
+
+		result := MaskedAnd(a, b, math.MaxUint64)
+		require.Equal(t, 0, result.GetCardinality())
+	})
+
+	t.Run("matches Masked(And(a,b))", func(t *testing.T) {
+		masks := []uint64{0, 0x0000FFFFFFFFFFFF, math.MaxUint64, 0x00000000FFFF0000}
+
+		a := NewBitmap()
+		b := NewBitmap()
+		for pos := uint64(0); pos < 5; pos++ {
+			for v := uint64(0); v < 100; v++ {
+				a.Set(pos<<48 | v)
+				// b overlaps on even positions only
+				if pos%2 == 0 {
+					b.Set(pos<<48 | v)
+				}
+			}
+		}
+
+		for _, m := range masks {
+			expected := And(a, b).Masked(m)
+			got := MaskedAnd(a, b, m)
+
+			require.Equal(t, expected.GetCardinality(), got.GetCardinality(), "mask %#x", m)
+			for _, v := range expected.ToArray() {
+				require.True(t, got.Contains(v), "mask %#x missing %d", m, v)
+			}
+		}
+	})
+
+	t.Run("key collision after masking merges via OR", func(t *testing.T) {
+		// Two key pairs that AND to non-empty, both mapping to same masked key.
+		a := NewBitmap()
+		b := NewBitmap()
+
+		// pos=1: a has {0,1}, b has {0,1} → AND = {0,1}
+		a.Set(0x0001_0000_0000 | 0)
+		a.Set(0x0001_0000_0000 | 1)
+		b.Set(0x0001_0000_0000 | 0)
+		b.Set(0x0001_0000_0000 | 1)
+
+		// pos=2: a has {2,3}, b has {2,3} → AND = {2,3}
+		a.Set(0x0002_0000_0000 | 2)
+		a.Set(0x0002_0000_0000 | 3)
+		b.Set(0x0002_0000_0000 | 2)
+		b.Set(0x0002_0000_0000 | 3)
+
+		// mask zeroes bits 32-63 → both key pairs collapse to masked key 0
+		result := MaskedAnd(a, b, 0x00000000FFFF0000)
+
+		require.Equal(t, 4, result.GetCardinality())
+		require.True(t, result.Contains(0))
+		require.True(t, result.Contains(1))
+		require.True(t, result.Contains(2))
+		require.True(t, result.Contains(3))
+	})
+
+	t.Run("does not modify either source", func(t *testing.T) {
+		a := NewBitmap()
+		a.Set(uint64(1)<<48 | 10)
+		a.Set(uint64(2)<<48 | 20)
+
+		b := NewBitmap()
+		b.Set(uint64(1)<<48 | 10)
+		b.Set(uint64(3)<<48 | 30)
+
+		aCard := a.GetCardinality()
+		bCard := b.GetCardinality()
+		_ = MaskedAnd(a, b, 0x0000FFFFFFFFFFFF)
+
+		require.Equal(t, aCard, a.GetCardinality())
+		require.Equal(t, bCard, b.GetCardinality())
+		require.True(t, a.Contains(uint64(1)<<48|10))
+		require.True(t, a.Contains(uint64(2)<<48|20))
+		require.True(t, b.Contains(uint64(1)<<48|10))
+		require.True(t, b.Contains(uint64(3)<<48|30))
+	})
+
+	t.Run("low 16 bits of mask are ignored", func(t *testing.T) {
+		a := NewBitmap()
+		b := NewBitmap()
+		a.Set(uint64(1)<<48 | 1)
+		b.Set(uint64(1)<<48 | 1)
+
+		r1 := MaskedAnd(a, b, 0x0000FFFFFFFFFFFF)
+		r2 := MaskedAnd(a, b, 0x0000FFFFFFFFFFFF|0xFFFF)
+
+		require.Equal(t, r1.GetCardinality(), r2.GetCardinality())
+		for _, v := range r1.ToArray() {
+			require.True(t, r2.Contains(v))
+		}
+	})
+}
+
+func TestMaskedAndToBuf(t *testing.T) {
+	t.Run("nil inputs", func(t *testing.T) {
+		var a, b *Bitmap
+		result := MaskedAndToBuf(a, b, math.MaxUint64, make([]byte, 4096))
+		require.Equal(t, 0, result.GetCardinality())
+	})
+
+	t.Run("matches MaskedAnd results", func(t *testing.T) {
+		a := NewBitmap()
+		b := NewBitmap()
+		for pos := uint64(0); pos < 5; pos++ {
+			for v := uint64(0); v < 100; v++ {
+				a.Set(pos<<48 | v)
+				b.Set(pos<<48 | v)
+			}
+		}
+
+		masks := []uint64{0, 0x0000FFFFFFFFFFFF, math.MaxUint64, 0x00000000FFFF0000}
+		for _, m := range masks {
+			expected := MaskedAnd(a, b, m)
+			got := MaskedAndToBuf(a, b, m, make([]byte, 1<<20))
+
+			require.Equal(t, expected.GetCardinality(), got.GetCardinality(), "mask %#x", m)
+			for _, v := range expected.ToArray() {
+				require.True(t, got.Contains(v), "mask %#x missing %d", m, v)
+			}
+		}
+	})
+
+	t.Run("no allocation when buffer is large enough", func(t *testing.T) {
+		a := NewBitmap()
+		b := NewBitmap()
+		for pos := uint64(0); pos < 5; pos++ {
+			for v := uint64(0); v < 100; v++ {
+				a.Set(pos<<48 | v)
+				b.Set(pos<<48 | v)
+			}
+		}
+
+		bufSize := 1 << 20
+		result := MaskedAndToBuf(a, b, 0x0000FFFFFFFFFFFF, make([]byte, bufSize))
+
+		require.Greater(t, result.GetCardinality(), 0)
+		require.Equal(t, bufSize, result.capInBytes(), "capacity should not change")
 	})
 }


### PR DESCRIPTION
## Motivation

  Two common patterns — `Masked(And(A, B))` and `A.And(B.Masked(mask))` — each force an intermediate bitmap allocation that is immediately discarded. For large bitmaps this is significant short-lived heap pressure.

  ## Approach

  **`MaskedAnd(a, b, mask)`** fuses `Masked(And(a, b))` into a single pass: the two-pointer walk over `a` and `b` writes directly into the result under `key & mask`, OR-ing containers when multiple original keys collide. One allocation instead of two.

  **`ra.AndMasked(b, mask)`** fuses `ra.And(b.Masked(mask))` without cloning `ra` or materialising a masked copy of `b`. It builds a compact sorted `[]maskedEntry` index over `b` (key–offset pairs only, no container data), walks `ra`'s containers, and for each key OR-s matching `b` containers inline into a scratch buffer before AND-ing into `ra` in place. A second scratch buffer (`fallbackBuf`) is only activated when an array+array OR triggers bitmap conversion and the result no longer fits in the source container.

  **`ra.AndMaskedConc`** parallelises `AndMasked` using the same `concurrentlyInRanges` infrastructure as `AndConc`. The entry index is built once and shared read-only; each goroutine binary-searches it for its starting position and uses its own scratch buffers.

  ## Key areas for review

  - `bitmap_opt.go:andMaskedContainersInRange` — the `orBuf`/`fallbackBuf` swap when inline OR fails; verify `orResult` correctly tracks the live buffer after each swap
  - `bitmap_opt.go:maskedEntriesFor` — the `from` hint only advances forward; callers must pass non-decreasing keys (guaranteed since `ra.keys` is sorted)
  - `bitmap_opt.go:buildMaskedEntries` — masking does not preserve key ordering so the sort is unconditional

  ## Testing

  `TestAndMasked` covers nil/empty inputs, identity mask, zero mask, non-overlapping arrays (size-based inline failure → swap), identical arrays (no swap), large arrays triggering bitmap conversion, and three-container groups. `TestAndMaskedConc` mirrors every scenario scaled to 72 keys (guaranteeing actual goroutine spawning) and verifies results against the sequential path at `maxConc` = 1, 2, 4, and 0.