### PR TITLE
feature: Intersects() and IntersectsMasked() — short-circuit set intersection checks

### DIFF
--- a/bitmap_opt.go
+++ b/bitmap_opt.go
@@ -7,6 +7,89 @@ import (
 	"sync"
 )
 
+// Intersects reports whether ra and bm share at least one element.
+// Equivalent to !ra.Clone().And(bm).IsEmpty() but short-circuits at the
+// first common element without allocating a result bitmap.
+func (ra *Bitmap) Intersects(bm *Bitmap) bool {
+	if ra.IsEmpty() || bm.IsEmpty() {
+		return false
+	}
+
+	an := ra.keys.numKeys()
+	bn := bm.keys.numKeys()
+	useGallopA := shouldGallop(an, bn)
+	useGallopB := shouldGallop(bn, an)
+
+	// Start bi at the first bm key >= ra's first key.
+	bi := bm.keys.search(ra.keys.key(0))
+
+	for ai := 0; ai < an && bi < bn; {
+		ak := ra.keys.key(ai)
+		bk := bm.keys.key(bi)
+		if ak == bk {
+			ac := ra.getContainer(ra.keys.val(ai))
+			bc := bm.getContainer(bm.keys.val(bi))
+			if containerIntersects(ac, bc) {
+				return true
+			}
+			ai++
+			bi++
+		} else if ak < bk {
+			if useGallopA {
+				ai = ra.keys.searchFrom(ai, bk)
+			} else {
+				ai++
+			}
+		} else {
+			if useGallopB {
+				bi = bm.keys.searchFrom(bi, ak)
+			} else {
+				bi++
+			}
+		}
+	}
+	return false
+}
+
+// IntersectsMasked reports whether ra and bm share at least one element after
+// applying mask to bm's keys. Equivalent to !ra.Clone().And(bm.Masked(mask)).IsEmpty()
+// but short-circuits at the first common element without allocating.
+// Containers in ra whose key has a non-zero dimension (low 16 bits != 0) are
+// not checked — same behaviour as AndMasked.
+func (ra *Bitmap) IntersectsMasked(bm *Bitmap, mask uint64) bool {
+	if ra.IsEmpty() || bm.IsEmpty() {
+		return false
+	}
+
+	mask &= 0xFFFFFFFFFFFF0000
+	entries := buildMaskedEntries(bm, mask)
+
+	var from int
+	var group []maskedEntry
+
+	an := ra.keys.numKeys()
+	for ai := 0; ai < an; ai++ {
+		ak := ra.keys.key(ai)
+		if uint16(ak) != 0 {
+			continue
+		}
+
+		group, from = maskedEntriesFor(entries, ak, from)
+		if group == nil {
+			continue
+		}
+
+		ac := ra.getContainer(ra.keys.val(ai))
+		for _, e := range group {
+			bc := bm.getContainer(e.offset)
+			if containerIntersects(ac, bc) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func And(a, b *Bitmap) *Bitmap {
 	res := NewBitmap()
 	if a.IsEmpty() || b.IsEmpty() {

--- a/bitmap_opt_test.go
+++ b/bitmap_opt_test.go
@@ -963,6 +963,119 @@ func TestLenBytes(t *testing.T) {
 	})
 }
 
+func TestIntersects(t *testing.T) {
+	t.Run("nil bitmaps return false", func(t *testing.T) {
+		var a, b *Bitmap
+		require.False(t, a.Intersects(b))
+		require.False(t, NewBitmap().Intersects(b))
+		require.False(t, a.Intersects(NewBitmap()))
+	})
+
+	t.Run("empty bitmaps return false", func(t *testing.T) {
+		require.False(t, NewBitmap().Intersects(NewBitmap()))
+	})
+
+	t.Run("no overlap returns false", func(t *testing.T) {
+		a := NewBitmap()
+		a.Set(1)
+		a.Set(2)
+		b := NewBitmap()
+		b.Set(3)
+		b.Set(4)
+		require.False(t, a.Intersects(b))
+	})
+
+	t.Run("single common element returns true", func(t *testing.T) {
+		a := NewBitmap()
+		a.Set(1)
+		a.Set(2)
+		b := NewBitmap()
+		b.Set(2)
+		b.Set(3)
+		require.True(t, a.Intersects(b))
+	})
+
+	t.Run("matches !Clone().And().IsEmpty()", func(t *testing.T) {
+		cases := []struct{ aVals, bVals []uint64 }{
+			{[]uint64{1, 2, 3}, []uint64{4, 5, 6}},
+			{[]uint64{1, 2, 3}, []uint64{3, 4, 5}},
+			{[]uint64{1, 2, 3}, []uint64{1, 2, 3}},
+			// keys in different containers
+			{[]uint64{1, 1 + uint64(maxCardinality)}, []uint64{2, 1 + uint64(maxCardinality)*2}},
+			{[]uint64{1, 1 + uint64(maxCardinality)}, []uint64{1 + uint64(maxCardinality)}},
+		}
+		for _, tc := range cases {
+			a, b := NewBitmap(), NewBitmap()
+			for _, v := range tc.aVals {
+				a.Set(v)
+			}
+			for _, v := range tc.bVals {
+				b.Set(v)
+			}
+			expected := !a.Clone().And(b).IsEmpty()
+			require.Equal(t, expected, a.Intersects(b))
+		}
+	})
+
+	t.Run("skewed sizes — a much larger than b", func(t *testing.T) {
+		a := NewBitmap()
+		for i := uint64(0); i < 2000; i++ {
+			a.Set(i << 16)
+		}
+		b := NewBitmap()
+		b.Set(1500 << 16)
+		require.True(t, a.Intersects(b))
+		b2 := NewBitmap()
+		b2.Set(9999 << 16) // not in a
+		require.False(t, a.Intersects(b2))
+	})
+}
+
+func TestIntersectsMasked(t *testing.T) {
+	const mask = uint64(0x0000FFFFFFFFFFFF)
+
+	t.Run("empty inputs return false", func(t *testing.T) {
+		var a, b *Bitmap
+		require.False(t, a.IntersectsMasked(b, mask))
+		require.False(t, NewBitmap().IntersectsMasked(b, mask))
+		require.False(t, a.IntersectsMasked(NewBitmap(), mask))
+		require.False(t, NewBitmap().IntersectsMasked(NewBitmap(), mask))
+	})
+
+	t.Run("no overlap returns false", func(t *testing.T) {
+		a := NewBitmap()
+		a.Set(uint64(1)<<48 | 1)
+		b := NewBitmap()
+		b.Set(uint64(2)<<48 | 2)
+		require.False(t, a.IntersectsMasked(b, mask))
+	})
+
+	t.Run("match via mask collapse returns true", func(t *testing.T) {
+		a := NewBitmap()
+		a.Set(1) // key=0, value=1
+		// b has key 0x0001<<48|0, masked to key 0: contains value 1
+		b := NewBitmap()
+		b.Set(uint64(1)<<48 | 1)
+		require.True(t, a.IntersectsMasked(b, mask))
+	})
+
+	t.Run("matches !Clone().And(bm.Masked(mask)).IsEmpty()", func(t *testing.T) {
+		masks := []uint64{0, 0x0000FFFFFFFFFFFF, math.MaxUint64, 0x00000000FFFF0000}
+		a := NewBitmap()
+		b := NewBitmap()
+		for pos := uint64(0); pos < 4; pos++ {
+			for v := uint64(0); v < 50; v++ {
+				a.Set(pos<<48 | v)
+				b.Set((pos+1)<<48 | v)
+			}
+		}
+		for _, m := range masks {
+			expected := !a.Clone().And(b.Masked(m)).IsEmpty()
+			require.Equal(t, expected, a.IntersectsMasked(b, m), "mask %#x", m)
+		}
+	})
+}
+
 func TestCapBytes(t *testing.T) {
 	t.Run("non-nil bitmap", func(t *testing.T) {
 		bm := NewBitmap()

--- a/container_opt.go
+++ b/container_opt.go
@@ -1,6 +1,9 @@
 package sroar
 
-import "math/bits"
+import (
+	"math/bits"
+	"slices"
+)
 
 var emptyArrayContainer []uint16
 
@@ -286,6 +289,55 @@ func (b bitmap) andBitmapAlt(other bitmap, optBuf []uint16, runMode int) []uint1
 		return out
 	}
 	return nil
+}
+
+func containerIntersects(ac, bc []uint16) bool {
+	at := ac[indexType]
+	bt := bc[indexType]
+	if at == typeArray && bt == typeArray {
+		return array(ac).intersectsArray(array(bc))
+	}
+	if at == typeArray && bt == typeBitmap {
+		return array(ac).intersectsBitmap(bitmap(bc))
+	}
+	if at == typeBitmap && bt == typeArray {
+		return array(bc).intersectsBitmap(bitmap(ac))
+	}
+	if at == typeBitmap && bt == typeBitmap {
+		return bitmap(ac).intersectsBitmap(bitmap(bc))
+	}
+	panic("containerIntersects: We should not reach here")
+}
+
+func (c array) intersectsArray(other array) bool {
+	cs := c.all()
+	os := other.all()
+	ci, oi := 0, 0
+	for ci < len(cs) && oi < len(os) {
+		if cs[ci] == os[oi] {
+			return true
+		} else if cs[ci] < os[oi] {
+			ci++
+		} else {
+			oi++
+		}
+	}
+	return false
+}
+
+func (c array) intersectsBitmap(other bitmap) bool {
+	return slices.ContainsFunc(c.all(), other.has)
+}
+
+func (b bitmap) intersectsBitmap(other bitmap) bool {
+	bs := uint16To64SliceUnsafe(b[startIdx:])
+	os := uint16To64SliceUnsafe(other[startIdx:])
+	for i := range bs {
+		if bs[i]&os[i] != 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func containerAndNotAlt(ac, bc []uint16, optBuf []uint16, runMode int) []uint16 {


### PR DESCRIPTION
## Motivation

  Checking whether two bitmaps share any element is a common operation, but the only available path was — which allocates a full result bitmap, computes the complete intersection, and then checks if it is empty. For large sparse bitmaps    that share no elements, this scans every key pair. For bitmaps that share an element early, it still computes the full AND before returning.

  ## Approach

  **`Intersects(bm)`** performs the same two-pointer key walk as `And` but returns `true` at the first matching container pair that shares an element, without building a result. Galloping (`shouldGallop`) is applied on both sides — the same threshold logic as `And`/`AndNot` — so skewed bitmaps skip large key gaps in O(log gap).

  **`IntersectsMasked(bm, mask)`** extends the check to the masked case: equivalent to `!ra.Clone().And(bm.Masked(mask)).IsEmpty()`.
  For each ra key, it finds all bm keys that collapse to the same masked value (via `buildMaskedEntries` + monotonic `maskedEntriesFor` scan) and checks each bm container individually against ra's container. The key insight is that `intersects(A, OR(B1, B2, ...)) = intersects(A, B1) OR intersects(A, B2) OR ...` — so the OR of the group never needs to be materialised; we exit on the first hit.

  Container-level dispatch follows the same pattern as `containerAndAlt`:
  - **bitmap × bitmap**: word-at-a-time AND, exits on first non-zero uint64 — leverages SIMD
  - **array × bitmap**: iterates array elements, probes bitmap with `has()`
  - **array × array**: two-pointer merge scan, exits on first equal element

  ## Key areas for review

  - `bitmap_opt.go:Intersects` — gallop flags are symmetric (both sides can gallop); verify `shouldGallop` is called correctly for both `useGallopA` and `useGallopB`
  - `bitmap_opt.go:IntersectsMasked` —  the `from` pointer advances monotonically so repeated `maskedEntriesFor` calls are O(1) amortized
  - `container_opt.go:bitmap.intersectsBitmap` — exits on first non-zero word; verify `uint16To64SliceUnsafe` slice lengths match between the two bitmaps (both are `maxContainerSize` by construction)

  ## Risks and mitigations

  - **No allocation, no mutation**: both methods are read-only; the only risk is a false negative (missing a common element), which the `matches !Clone().And().IsEmpty()` test cases guard against across multiple mask values and container type combinations
  - **Concurrency**: no concurrent variants added — `Intersects` short-circuits on the first match, so concurrency only helps the "no intersection" case; the goroutine coordination overhead outweighs the benefit for the common use pattern

  ## Testing

  `TestIntersects` and `TestIntersectsMasked` verify correctness against the reference `!Clone().And().IsEmpty()` across nil inputs, no-overlap, single-element overlap, skewed bitmap sizes, and multiple mask values including zero mask and identity mask.