### PR TITLE
feature: NumContainers() — direct container count accessor, removes CompareNumKeys()

### DIFF
--- a/bitmap_opt.go
+++ b/bitmap_opt.go
@@ -823,23 +823,11 @@ func (ra *Bitmap) ConvertToBitmapContainers() {
 	}
 }
 
-func (dst *Bitmap) CompareNumKeys(src *Bitmap) int {
-	if dst == nil && src == nil {
+func (ra *Bitmap) NumContainers() int {
+	if ra == nil {
 		return 0
 	}
-	if src == nil {
-		return 1
-	}
-	if dst == nil {
-		return -1
-	}
-	if dstN, srcN := dst.keys.numKeys(), src.keys.numKeys(); dstN > srcN {
-		return 1
-	} else if dstN < srcN {
-		return -1
-	} else {
-		return 0
-	}
+	return ra.keys.numKeys()
 }
 
 func (ra *Bitmap) LenInBytes() int {

--- a/bitmap_opt_test.go
+++ b/bitmap_opt_test.go
@@ -885,56 +885,48 @@ func TestIssue_Or_NotMergeContainers(t *testing.T) {
 	})
 }
 
-func TestCompareNumKeys(t *testing.T) {
-	var bmNil *Bitmap
+func TestNumContainers(t *testing.T) {
+	t.Run("nil bitmap", func(t *testing.T) {
+		var bm *Bitmap
+		require.Equal(t, 0, bm.NumContainers())
+	})
 
-	bm1Key := NewBitmap()
-	bm1Key.Set(1)
+	t.Run("empty bitmap", func(t *testing.T) {
+		// NewBitmap always pre-allocates the zero-key container, which Cleanup
+		// also never removes, so an empty bitmap has 1 container.
+		bm := NewBitmap()
+		require.Equal(t, 1, bm.NumContainers())
+	})
 
-	bm2Keys := NewBitmap()
-	bm2Keys.Set(1)
-	bm2Keys.Set(1 + uint64(maxCardinality))
+	t.Run("single container", func(t *testing.T) {
+		bm := NewBitmap()
+		bm.Set(1)
+		require.Equal(t, 1, bm.NumContainers())
+	})
 
-	bm3Keys := NewBitmap()
-	bm3Keys.Set(1)
-	bm3Keys.Set(1 + uint64(maxCardinality))
-	bm3Keys.Set(1 + uint64(maxCardinality)*2)
-
-	t.Run("greater", func(t *testing.T) {
-		for _, bms := range [][2]*Bitmap{
-			{bm1Key, bmNil},
-			{bm2Keys, bmNil},
-			{bm2Keys, bm1Key},
-			{bm3Keys, bmNil},
-			{bm3Keys, bm1Key},
-			{bm3Keys, bm2Keys},
-		} {
-			require.Equal(t, 1, bms[0].CompareNumKeys(bms[1]))
+	t.Run("grows with each new container", func(t *testing.T) {
+		bm := NewBitmap()
+		for i, x := range []uint64{1, 1 + uint64(maxCardinality), 1 + uint64(maxCardinality)*2} {
+			bm.Set(x)
+			require.Equal(t, i+1, bm.NumContainers())
 		}
 	})
 
-	t.Run("equal", func(t *testing.T) {
-		for _, bms := range [][2]*Bitmap{
-			{bmNil, bmNil},
-			{bm1Key, bm1Key},
-			{bm2Keys, bm2Keys},
-			{bm3Keys, bm3Keys},
-		} {
-			require.Equal(t, 0, bms[0].CompareNumKeys(bms[1]))
+	t.Run("values in same container don't increase count", func(t *testing.T) {
+		bm := NewBitmap()
+		for x := uint64(0); x < uint64(maxCardinality); x++ {
+			bm.Set(x)
 		}
+		require.Equal(t, 1, bm.NumContainers())
 	})
 
-	t.Run("less", func(t *testing.T) {
-		for _, bms := range [][2]*Bitmap{
-			{bmNil, bm1Key},
-			{bmNil, bm2Keys},
-			{bmNil, bm3Keys},
-			{bm1Key, bm2Keys},
-			{bm1Key, bm3Keys},
-			{bm2Keys, bm3Keys},
-		} {
-			require.Equal(t, -1, bms[0].CompareNumKeys(bms[1]))
-		}
+	t.Run("setting maxCardinality+1 yields 2 containers", func(t *testing.T) {
+		// The zero-key container covers [0, maxCardinality) and is always
+		// pre-allocated, so adding a value just beyond that boundary must
+		// create a second container.
+		bm := NewBitmap()
+		bm.Set(uint64(maxCardinality) + 1)
+		require.Equal(t, 2, bm.NumContainers())
 	})
 }
 


### PR DESCRIPTION
## Motivation                                                                                                             
                                                                                                                            
  `CompareNumKeys` exposed the internal container count only indirectly, as a three-way comparison between two bitmaps. Callers that simply need to know how many containers a single bitmap holds had no clean way to get that number.           
                                                                                                                 
  ## Approach                                                                                                               
                                                                                                                          
  **`NumContainers()`** returns `ra.keys.numKeys()` directly — the same count that `GetCardinality`, `IsEmpty`, and the
  set-operation loops already iterate over internally. The method follows the nil-safe convention of the rest of the API (returns 0 for a nil receiver).                                                                                       
                                                                                                                            
  `CompareNumKeys` is removed; callers that need an ordering can compare `a.NumContainers()` against `b.NumContainers()` directly.                                                                                                                 
           
  ## Key areas for review                                                                                                   
                                                            
  - `bitmap_opt.go:NumContainers` — single-line delegation to `keys.numKeys()`; verify nil guard is consistent with
  `GetCardinality` and `LenInBytes`                                                                                         
                                   
  ## Risks and mitigations                                                                                                  
                                                            
  - **Pre-allocated zero-key container**: `NewBitmap()` always starts with one container, and `Cleanup` explicitly never
  removes it (`idx` starts at 1). `NumContainers()` counts it, so an empty bitmap returns 1, not 0. This is documented in   
  the test.                                                                                                              
                                                                                                                            
  ## Testing                                                
            
  `TestNumContainers` covers: nil receiver, empty bitmap (documents the pre-allocated container), single container,
  incremental growth across three containers, filling one container to capacity without crossing the boundary, and a direct 
  proof that `Set(maxCardinality+1)` produces exactly 2 containers.