### PR TITLE
feature: CopresenceByMask() and CopresenceByMaskToBuf() — N-ary masked co-presence in one pass

### DIFF
--- a/bitmap_opt.go
+++ b/bitmap_opt.go
@@ -1493,6 +1493,498 @@ func (ra *Bitmap) AndMaskedConc(b *Bitmap, mask uint64, maxConcurrency int) *Bit
 	return ra
 }
 
+// CopresenceByMask returns a new bitmap containing every value v in the
+// union of bms whose masked value (v & mask) is present in bms[i].Masked(mask)
+// for every i. Original (unmasked) values are preserved. Equivalent in
+// result to the (much more expensive) fold:
+//
+//	out := bms[0].Masked(mask)
+//	for i := 1; i < len(bms); i++ {
+//	    out = out.And(bms[i].Masked(mask))
+//	}
+//	// then map each masked value back to every original v in any bms[i]
+//	// whose v & mask matches.
+//
+// but processes all inputs in one pass — avoiding intermediate bitmap
+// allocations and walking each input only once. None of the bms are
+// modified.
+//
+// Mask shape requirement: mask & 0xFFFF == 0xFFFF. Other mask shapes are
+// not supported and will yield incorrect results.
+//
+// Edge cases:
+//   - len(bms) == 0: empty result.
+//   - len(bms) == 1: result is a clone of bms[0] (single-input co-presence
+//     is trivially the input).
+//   - any input empty: empty result.
+//
+// Algorithm: with mask_high = mask & 0xFFFFFFFFFFFF0000, group each input's
+// containers by K & mask_high. Walk the masked-key entry slices of all N
+// inputs in lockstep (multi-pointer max-key advance) to find groups present
+// on every side. For each such group:
+//  1. compute pos_i = OR of positions across input i's containers in the group
+//  2. common_pos = AND_i (pos_i) — positions co-present in every side
+//  3. for each unique original key K appearing in any input's group, emit
+//     OR_i(bms[i][K]) AND common_pos at K (omitting empty results)
+//
+// Step 2 short-circuits as soon as common_pos becomes empty.
+func CopresenceByMask(bms []*Bitmap, mask uint64) *Bitmap {
+	if len(bms) == 0 {
+		return NewBitmap()
+	}
+	if len(bms) == 1 {
+		return bms[0].Clone()
+	}
+	return copresenceByMaskInto(bms, mask, NewBitmap())
+}
+
+// CopresenceByMaskToBuf is like [CopresenceByMask] but uses the provided
+// byte slice as the underlying buffer for the result bitmap, avoiding the
+// result's heap allocation when the buffer is large enough. If the buffer
+// is too small the bitmap grows internally (and allocates), so correctness
+// is unaffected — only the allocation-elision is.
+//
+// Sizing guidance: a safe upper bound is the sum of input byte sizes
+// (sum_i bms[i].LenInBytes()). The result's keys area is bounded by the
+// sum of input keys areas, and each result container is bounded by the
+// sum of its contributing inputs' containers (the per-key OR can't exceed
+// it; the subsequent AND with commonPos can only shrink). In practice
+// results are often much smaller — callers that know their workload's
+// typical density can pass a smaller buffer and accept occasional growth.
+//
+// Same mask shape requirement as [CopresenceByMask]: mask & 0xFFFF == 0xFFFF.
+func CopresenceByMaskToBuf(bms []*Bitmap, mask uint64, buf []byte) *Bitmap {
+	if len(bms) == 0 {
+		return NewBitmapToBuf(buf)
+	}
+	if len(bms) == 1 {
+		return bms[0].CloneToBuf(buf)
+	}
+	return copresenceByMaskInto(bms, mask, NewBitmapToBuf(buf))
+}
+
+// copresenceByMaskInto is the shared body of [CopresenceByMask] and
+// [CopresenceByMaskToBuf]. Caller must ensure len(bms) >= 2; the N=0 and
+// N=1 short-circuits are handled at the public entry points because they
+// differ in how `res` is constructed (NewBitmap vs Clone[ToBuf]).
+func copresenceByMaskInto(bms []*Bitmap, mask uint64, res *Bitmap) *Bitmap {
+	n := len(bms)
+	for _, bm := range bms {
+		if bm.IsEmpty() {
+			return res
+		}
+	}
+
+	maskHigh := mask & 0xFFFFFFFFFFFF0000
+
+	allEntries := make([][]keyedMaskedEntry, n)
+	totalEntries := 0
+	for i, bm := range bms {
+		allEntries[i] = buildKeyedMaskedEntries(bm, maskHigh)
+		if len(allEntries[i]) == 0 {
+			return res
+		}
+		totalEntries += len(allEntries[i])
+	}
+
+	// Pre-size res's keys area for an estimated result-key count to avoid
+	// expandKeys-driven shifts during emission. The result has at most one
+	// emitted key per non-empty container across all inputs (sum of
+	// totalEntries), so sum/N (the average per input) is a middle-ground
+	// estimate: under-estimates only when distinct keys-per-masked-group
+	// exceed the per-input average. Under-allocation is recoverable
+	// (expandKeys still fires); the goal is to skip it in the common case.
+	res.expandConditionally(totalEntries/n, 0)
+
+	// Three scratch buffers carry the full algorithm:
+	//   - posBufA / posFallbackA back the OR over the seed group. The result
+	//     becomes commonPos (mutated via AND-in-place across the AND-fold);
+	//     the unused half is returned as `spare` and reused below.
+	//   - posBufB is the third buffer. Paired with `spare`, it backs the
+	//     OR over each non-seed group during the AND-fold.
+	// Once the AND-fold completes, `spare` and `posBufB` are free (their
+	// last contents are the last iPos's OR-result, already folded into
+	// commonPos). Emit reuses them as its mergeBuf and mergeFallback —
+	// emit needs no third buffer because its final AND target is also
+	// mergeFallback (mergeBuf/mergeFallback always point to different
+	// underlying buffers, so writing to mergeFallback never aliases merged).
+	posBufA := make([]uint16, maxContainerSize)
+	posFallbackA := make([]uint16, maxContainerSize)
+	posBufB := make([]uint16, maxContainerSize)
+
+	entryCursors := make([]int, n)
+	emitCursors := make([]int, n)
+	groups := make([][]keyedMaskedEntry, n)
+	// foldOrder[k] is the index of the input to fold at position k of the
+	// AND-fold. Sorted by ascending estimated |pos_i| so the smallest pos_i
+	// seeds commonPos — minimizing intermediate sizes and maximizing the
+	// chance of early break-on-empty. cardEst[i] holds the cardinality
+	// upper bound (sum of container cardinalities) for input i in the
+	// current masked group. Both reused across iterations.
+	foldOrder := make([]int, n)
+	cardEst := make([]int, n)
+
+	for nextCommonGroup(allEntries, entryCursors, groups) {
+		buildFoldOrder(bms, groups, foldOrder, cardEst)
+
+		// commonPos lives in a buffer we mutate via AND-in-place; spare
+		// is the other of posBufA/posFallbackA, reused as one of the two
+		// buffers for every subsequent iPos OR (and again for emit).
+		seed := foldOrder[0]
+		commonPos, spare := orPositionsInGroup(bms[seed], groups[seed], posBufA, posFallbackA)
+		for k := 1; k < n; k++ {
+			i := foldOrder[k]
+			iPos := orPositionsInGroupReadOnly(bms[i], groups[i], spare, posBufB)
+			if c := containerAndAlt(commonPos, iPos, nil, runInline); len(c) > 0 {
+				panic("CopresenceByMask: AND inline returned a new container")
+			}
+			if getCardinality(commonPos) == 0 {
+				break
+			}
+		}
+		if getCardinality(commonPos) == 0 {
+			continue
+		}
+
+		clear(emitCursors)
+		// spare and posBufB held the last iPos's data, which has already
+		// been AND-folded into commonPos. Free to reuse as emit's merge
+		// pair.
+		emitGroupFilteredN(bms, groups, emitCursors, commonPos, spare, posBufB, res)
+	}
+	return res
+}
+
+// buildFoldOrder writes input indices into foldOrder, sorted ascending by
+// estimated |pos_i| (the OR of positions across input i's containers in
+// the current masked group). The estimate is the sum of those containers'
+// cardinalities — exact for single-container groups, an upper bound when
+// containers' positions can overlap.
+//
+// Sorting smallest-first seeds the AND-fold with the smallest pos_i,
+// minimizing intermediate sizes and maximizing the chance of early
+// break-on-empty.
+//
+// cardEst is caller-provided scratch the same length as foldOrder; its
+// contents are overwritten on each call.
+//
+// Small-N fast paths matter: this is called once per masked-group
+// iteration on the hot path. slices.SortFunc has enough per-call overhead
+// that it would dominate per-iteration cost for N=2 (the most common case
+// via the binary entry point).
+func buildFoldOrder(
+	bms []*Bitmap, groups [][]keyedMaskedEntry,
+	foldOrder, cardEst []int,
+) {
+	n := len(groups)
+	for i := 0; i < n; i++ {
+		sum := 0
+		for _, e := range groups[i] {
+			sum += getCardinality(bms[i].data[e.offset:])
+		}
+		cardEst[i] = sum
+		foldOrder[i] = i
+	}
+
+	switch n {
+	case 0, 1:
+		return
+	case 2:
+		// foldOrder is [0, 1] (identity); swap if cardEst[1] < cardEst[0].
+		if cardEst[1] < cardEst[0] {
+			foldOrder[0], foldOrder[1] = 1, 0
+		}
+	default:
+		slices.SortFunc(foldOrder, func(a, b int) int {
+			return cardEst[a] - cardEst[b]
+		})
+	}
+}
+
+// nextCommonGroup advances entryCursors to the next masked-key value that
+// is present in all inputs, then writes the per-input slice of entries
+// sharing that key into groups. Returns false when no further common key
+// exists (i.e. at least one cursor has been exhausted).
+//
+// Both entryCursors and groups are mutated in place so the caller can reuse
+// them across iterations without per-call allocation. groups must already
+// have length len(allEntries); its slice headers are overwritten.
+//
+// Algorithm: multi-pointer max-key walk. At each step, find the largest
+// masked-key value under any cursor and gallop every cursor below it
+// forward to the first entry with maskedKey >= that target. Repeat until
+// either all cursors agree on the same key (a common group is found) or
+// some cursor runs off the end (no more common groups possible). Galloping
+// is repeated rather than done in a single pass because cursors that
+// advance past their previous key may land on a value higher than the
+// previous max — forcing a new round of alignment.
+func nextCommonGroup(
+	allEntries [][]keyedMaskedEntry, entryCursors []int, groups [][]keyedMaskedEntry,
+) bool {
+	n := len(allEntries)
+	for {
+		// Exhaustion check: any cursor at end → no more common groups possible.
+		for i := 0; i < n; i++ {
+			if entryCursors[i] >= len(allEntries[i]) {
+				return false
+			}
+		}
+
+		// Find max masked-key under current cursors.
+		maxKey := allEntries[0][entryCursors[0]].maskedKey
+		for i := 1; i < n; i++ {
+			if k := allEntries[i][entryCursors[i]].maskedKey; k > maxKey {
+				maxKey = k
+			}
+		}
+
+		// Gallop any cursor below maxKey forward to the first entry >= maxKey.
+		advanced := false
+		for i := 0; i < n; i++ {
+			if entryCursors[i] < len(allEntries[i]) && allEntries[i][entryCursors[i]].maskedKey < maxKey {
+				entryCursors[i] = searchKeyedMaskedFrom(allEntries[i], entryCursors[i], maxKey)
+				advanced = true
+			}
+		}
+		if advanced {
+			continue
+		}
+
+		// All cursors agree on maxKey: collect each input's group of entries
+		// sharing that masked key, advance cursors past them, return.
+		for i := 0; i < n; i++ {
+			start := entryCursors[i]
+			for entryCursors[i] < len(allEntries[i]) && allEntries[i][entryCursors[i]].maskedKey == maxKey {
+				entryCursors[i]++
+			}
+			groups[i] = allEntries[i][start:entryCursors[i]]
+		}
+		return true
+	}
+}
+
+// keyedMaskedEntry pairs a container's offset and original key with the
+// masked-key value used for grouping. Sorted slices of these support
+// two-pointer walks over masked-key groups while preserving access to the
+// original (unmasked) key for emission.
+type keyedMaskedEntry struct {
+	maskedKey   uint64
+	originalKey uint64
+	offset      uint64
+}
+
+// buildKeyedMaskedEntries returns a slice of entries for bm, one per
+// non-empty container, sorted by (maskedKey, originalKey). Sorting by
+// originalKey within a masked group lets the per-group emission walk both
+// sides in parallel by original key.
+func buildKeyedMaskedEntries(bm *Bitmap, mask uint64) []keyedMaskedEntry {
+	n := bm.keys.numKeys()
+	entries := make([]keyedMaskedEntry, 0, n)
+	for i := 0; i < n; i++ {
+		offset := bm.keys.val(i)
+		if getCardinality(bm.data[offset:]) == 0 {
+			continue
+		}
+		key := bm.keys.key(i)
+		entries = append(entries, keyedMaskedEntry{
+			maskedKey:   key & mask,
+			originalKey: key,
+			offset:      offset,
+		})
+	}
+	slices.SortFunc(entries, func(a, b keyedMaskedEntry) int {
+		if a.maskedKey != b.maskedKey {
+			if a.maskedKey < b.maskedKey {
+				return -1
+			}
+			return 1
+		}
+		if a.originalKey < b.originalKey {
+			return -1
+		}
+		if a.originalKey > b.originalKey {
+			return 1
+		}
+		return 0
+	})
+	return entries
+}
+
+// searchKeyedMaskedFrom returns the index of the smallest entry whose
+// maskedKey >= target, starting the search at from+1. The caller must
+// guarantee entries[from].maskedKey < target (i.e. that an advance is
+// actually needed). Returns len(entries) if no such entry exists.
+//
+// Uses exponential search to bracket the target then binary search to
+// pinpoint it — O(log gap) where gap is the distance from `from` to the
+// result. Mirrors keys.searchFrom for []keyedMaskedEntry. Equivalent in
+// outcome to a linear `for cursor++` advance but logarithmically faster
+// when one input has a long stretch of masked keys absent from another.
+func searchKeyedMaskedFrom(entries []keyedMaskedEntry, from int, target uint64) int {
+	N := len(entries)
+	lower := from + 1
+	if lower >= N || entries[lower].maskedKey >= target {
+		return lower
+	}
+	// Exponential expansion to bracket target.
+	span := 1
+	for lower+span < N && entries[lower+span].maskedKey < target {
+		span *= 2
+	}
+	upper := lower + span
+	if upper >= N {
+		upper = N - 1
+	}
+	if entries[upper].maskedKey < target {
+		return N
+	}
+	// Binary search within [lower + span/2, upper].
+	lower += span >> 1
+	for lower+1 < upper {
+		mid := (lower + upper) >> 1
+		k := entries[mid].maskedKey
+		if k < target {
+			lower = mid
+		} else if k > target {
+			upper = mid
+		} else {
+			return mid
+		}
+	}
+	return upper
+}
+
+// orPositionsInGroupReadOnly is the no-copy variant of orPositionsInGroup
+// for callers that will treat the result as read-only. For a single-container
+// group it returns the source container slice directly (no buffer write);
+// otherwise it falls through to orPositionsInGroup. The returned slice MUST
+// NOT be mutated by the caller — use only as an input to operations that
+// do not modify their arguments (e.g. AND into a separate accumulator
+// buffer, never AND-in-place into this slice). The spare return from the
+// underlying orPositionsInGroup is dropped since this variant's callers
+// don't track it.
+func orPositionsInGroupReadOnly(bm *Bitmap, group []keyedMaskedEntry, bufA, bufB []uint16) []uint16 {
+	if len(group) == 1 {
+		return bm.getContainer(group[0].offset)
+	}
+	result, _ := orPositionsInGroup(bm, group, bufA, bufB)
+	return result
+}
+
+// orPositionsInGroup returns a slice holding the OR of all containers
+// referenced by group (using bm for data). bufA and bufB are scratch.
+//
+// Returns (result, spare):
+//   - result points to the buffer holding the OR.
+//   - spare points to the OTHER of {bufA, bufB} and is available to the
+//     caller for any unrelated use — its contents are stale OR-intermediate
+//     data but no live references remain.
+//
+// The first container is copied into bufA so the source containers are
+// never mutated; subsequent ORs use the runInline + fallback swap pattern.
+func orPositionsInGroup(bm *Bitmap, group []keyedMaskedEntry, bufA, bufB []uint16) (result, spare []uint16) {
+	first := bm.getContainer(group[0].offset)
+	copy(bufA, first)
+	result, spare = bufA, bufB
+
+	for i := 1; i < len(group); i++ {
+		c := containerOrAlt(result, bm.getContainer(group[i].offset), spare, runInline)
+		if len(c) > 0 {
+			// Inline failed (array→bitmap conversion): result is now in spare.
+			result, spare = spare, result
+		}
+	}
+	return result, spare
+}
+
+// emitGroupFilteredN walks all N groups in lockstep by originalKey. For
+// each unique original key K appearing in any of the groups, it emits
+// OR_i(bms[i][K]) AND commonPos at K in res when non-empty.
+//
+// Buffer protocol for the per-key OR over up to N source containers:
+//   - First source contributing to K: `merged` aliases the source slice
+//     directly (no copy).
+//   - Second source: OR via mode-0 into mergeBuf, `merged` now points to
+//     mergeBuf.
+//   - Third+ source: OR via runInline into mergeFallback, swapping
+//     mergeBuf/mergeFallback when inline grows the container.
+//
+// The final AND with commonPos writes into mergeFallback (mode 0). After
+// the per-key OR, mergeBuf and mergeFallback always point to different
+// underlying buffers (any swaps stay paired), and `merged` is either a
+// source slice or sits in mergeBuf — never in mergeFallback. So writing
+// to mergeFallback never aliases merged. No third buffer needed.
+//
+// cursors must be zeroed by the caller.
+func emitGroupFilteredN(
+	bms []*Bitmap, groups [][]keyedMaskedEntry, cursors []int,
+	commonPos, mergeBuf, mergeFallback []uint16, res *Bitmap,
+) {
+	n := len(bms)
+	for {
+		minKey, ok := nextEmitKey(groups, cursors)
+		if !ok {
+			return
+		}
+
+		// Build merged = OR of all containers at minKey across inputs.
+		var merged []uint16
+		mergedCount := 0
+		for i := 0; i < n; i++ {
+			if cursors[i] >= len(groups[i]) {
+				continue
+			}
+			if groups[i][cursors[i]].originalKey != minKey {
+				continue
+			}
+			c := bms[i].getContainer(groups[i][cursors[i]].offset)
+			cursors[i]++
+
+			switch mergedCount {
+			case 0:
+				merged = c
+			case 1:
+				merged = containerOrAlt(merged, c, mergeBuf, 0)
+			default:
+				if r := containerOrAlt(merged, c, mergeFallback, runInline); len(r) > 0 {
+					mergeBuf, mergeFallback = mergeFallback, mergeBuf
+					merged = r
+				}
+			}
+			mergedCount++
+		}
+
+		filtered := containerAndAlt(merged, commonPos, mergeFallback, 0)
+		if len(filtered) > 0 && getCardinality(filtered) > 0 {
+			offset := res.newContainerNoClr(uint16(len(filtered)))
+			copy(res.data[offset:], filtered)
+			res.setKey(minKey, offset)
+		}
+	}
+}
+
+// nextEmitKey returns the smallest originalKey under any active cursor in
+// groups, or (0, false) when every cursor has reached its group's end.
+// Mirrors nextCommonGroup's role for the per-group emission walk: drives
+// the N-way merge over per-input entry slices that share a common masked
+// key. Does not mutate cursors — the caller advances them while collecting
+// the containers at the returned key.
+func nextEmitKey(groups [][]keyedMaskedEntry, cursors []int) (uint64, bool) {
+	var minKey uint64
+	found := false
+	for i := 0; i < len(groups); i++ {
+		if cursors[i] >= len(groups[i]) {
+			continue
+		}
+		k := groups[i][cursors[i]].originalKey
+		if !found || k < minKey {
+			minKey = k
+			found = true
+		}
+	}
+	return minKey, found
+}
+
 func andMaskedContainersInRange(ra, b *Bitmap, entries []maskedEntry, ai, aj int) {
 	// orBuf holds the accumulated OR result across the group.
 	// fallbackBuf is needed only when inline OR fails (array+array that must

--- a/bitmap_opt_test.go
+++ b/bitmap_opt_test.go
@@ -3223,7 +3223,7 @@ func TestAndMasked(t *testing.T) {
 		for v := uint64(half); v < 2*half; v++ {
 			b.Set(0x00020000 | v) // key 2 → masked 0, triggers swap with key 1
 		}
-		for v := uint64(2*half); v < 3*half; v++ {
+		for v := uint64(2 * half); v < 3*half; v++ {
 			b.Set(0x00030000 | v) // key 3 → masked 0, OR'd into bitmap inline
 		}
 
@@ -3399,7 +3399,7 @@ func TestAndMaskedConc(t *testing.T) {
 			for v := uint64(half); v < 2*half; v++ {
 				b.Set(uint64(2)<<32 | k<<16 | v)
 			}
-			for v := uint64(2*half); v < 3*half; v++ {
+			for v := uint64(2 * half); v < 3*half; v++ {
 				b.Set(uint64(3)<<32 | k<<16 | v)
 			}
 		}
@@ -3425,5 +3425,474 @@ func TestAndMaskedConc(t *testing.T) {
 		for _, v := range bValues {
 			require.True(t, b.Contains(v))
 		}
+	})
+}
+
+func TestCopresenceByMask(t *testing.T) {
+	// pos packs three fields into a uint64 to give readable test data:
+	//   bits 63-50: hi  (14 bits) — preserved by maskZeroMid
+	//   bits 49-36: mid (14 bits) — zeroed by maskZeroMid
+	//   bits 35-0:  lo  (36 bits) — preserved by maskZeroMid
+	pos := func(hi, mid, lo uint64) uint64 {
+		return (hi << 50) | (mid << 36) | lo
+	}
+	// maskZeroMid keeps hi and lo, zeroes mid. mask & 0xFFFF == 0xFFFF —
+	// satisfies CopresenceByMask's mask-shape requirement.
+	const maskZeroMid uint64 = ^(uint64(0x3FFF) << 36)
+
+	bm := func(values ...uint64) *Bitmap {
+		b := NewBitmap()
+		b.SetMany(values)
+		return b
+	}
+
+	// safeBufSize implements the documented upper bound for CopresenceByMaskToBuf:
+	// sum of input byte sizes. Sized this way, the buf is guaranteed to fit the
+	// result without internal growth.
+	safeBufSize := func(bms []*Bitmap) int {
+		total := 0
+		for _, b := range bms {
+			total += b.LenInBytes()
+		}
+		return total
+	}
+
+	// runBoth exercises a test case through both call paths and asserts the
+	// same result via `check`. CopresenceByMaskToBuf is sized using
+	// safeBufSize so it never needs to grow internally.
+	runBoth := func(t *testing.T, inputs []*Bitmap, mask uint64, check func(t *testing.T, got *Bitmap)) {
+		t.Helper()
+		t.Run("plain", func(t *testing.T) {
+			check(t, CopresenceByMask(inputs, mask))
+		})
+		t.Run("ToBuf", func(t *testing.T) {
+			check(t, CopresenceByMaskToBuf(inputs, mask, make([]byte, safeBufSize(inputs))))
+		})
+	}
+
+	tests := []struct {
+		name   string
+		inputs []*Bitmap
+		mask   uint64
+		want   []uint64
+	}{
+		// --- Edge cases ----------------------------------------------------
+		{
+			name:   "empty slice returns empty",
+			inputs: []*Bitmap{},
+			mask:   maskZeroMid,
+			want:   []uint64{},
+		},
+		{
+			name:   "single input is preserved as-is",
+			inputs: []*Bitmap{bm(pos(1, 1, 5), pos(2, 7, 9))},
+			mask:   maskZeroMid,
+			want:   []uint64{pos(1, 1, 5), pos(2, 7, 9)},
+		},
+		{
+			name:   "all inputs empty returns empty",
+			inputs: []*Bitmap{bm(), bm()},
+			mask:   maskZeroMid,
+			want:   []uint64{},
+		},
+		{
+			name:   "first input empty returns empty",
+			inputs: []*Bitmap{bm(), bm(pos(1, 1, 1))},
+			mask:   maskZeroMid,
+			want:   []uint64{},
+		},
+		{
+			name:   "second input empty returns empty",
+			inputs: []*Bitmap{bm(pos(1, 1, 1)), bm()},
+			mask:   maskZeroMid,
+			want:   []uint64{},
+		},
+		{
+			name: "any empty input among many short-circuits to empty",
+			inputs: []*Bitmap{
+				bm(pos(1, 1, 5)),
+				NewBitmap(),
+				bm(pos(1, 2, 5)),
+			},
+			mask: maskZeroMid,
+			want: []uint64{},
+		},
+
+		// --- Binary cases --------------------------------------------------
+		{
+			// a={(1,1,1)}, b={(1,2,1),(1,3,1)}. After masking mid=0 each
+			// side maps to {(1,0,1)}. Common = {(1,0,1)} → all originals
+			// emit (different mid values are kept distinct in the result).
+			name:   "shared masked group: union of contributing mid values",
+			inputs: []*Bitmap{bm(pos(1, 1, 1)), bm(pos(1, 2, 1), pos(1, 3, 1))},
+			mask:   maskZeroMid,
+			want:   []uint64{pos(1, 1, 1), pos(1, 2, 1), pos(1, 3, 1)},
+		},
+		{
+			// a→{(1,0,8)}, b→{(2,0,8)}. Different masked groups — no co-presence.
+			name:   "different hi yields disjoint masked groups",
+			inputs: []*Bitmap{bm(pos(1, 1, 8)), bm(pos(2, 1, 8))},
+			mask:   maskZeroMid,
+			want:   []uint64{},
+		},
+		{
+			// Same hi, but lo differs: a→{(1,0,1)}, b→{(1,0,2)}. Common = ∅.
+			name:   "same hi different lo: no co-presence on lo",
+			inputs: []*Bitmap{bm(pos(1, 1, 1)), bm(pos(1, 2, 2))},
+			mask:   maskZeroMid,
+			want:   []uint64{},
+		},
+		{
+			// a's lo set = {1,2,3}, b's lo = {2}. Only lo=2 is shared.
+			// Result emits both originals whose lo is 2.
+			name: "lo intersection: only shared lo values survive",
+			inputs: []*Bitmap{
+				bm(pos(1, 1, 1), pos(1, 1, 2), pos(1, 1, 3)),
+				bm(pos(1, 2, 2)),
+			},
+			mask: maskZeroMid,
+			want: []uint64{pos(1, 1, 2), pos(1, 2, 2)},
+		},
+		{
+			// Two distinct masked groups (hi=1 and hi=2) are each co-present
+			// on their respective sides; both contribute fully.
+			name: "two distinct shared groups both contribute",
+			inputs: []*Bitmap{
+				bm(pos(1, 1, 1), pos(2, 1, 1)),
+				bm(pos(1, 2, 1), pos(2, 2, 1)),
+			},
+			mask: maskZeroMid,
+			want: []uint64{
+				pos(1, 1, 1), pos(1, 2, 1),
+				pos(2, 1, 1), pos(2, 2, 1),
+			},
+		},
+		{
+			// hi=1 only in a, hi=2 in both. Only hi=2 group contributes.
+			name: "one shared group, the other only in a is filtered out",
+			inputs: []*Bitmap{
+				bm(pos(1, 1, 9), pos(2, 1, 9)),
+				bm(pos(2, 2, 9)),
+			},
+			mask: maskZeroMid,
+			want: []uint64{pos(2, 1, 9), pos(2, 2, 9)},
+		},
+		{
+			// a→{(3,0,100)}; b→{(1,0,100),(3,0,100)}. Common = {(3,0,100)}.
+			// b's pos(1,5,100) is filtered out — its masked value is unique to b.
+			name: "extra container in b filtered out by partial overlap",
+			inputs: []*Bitmap{
+				bm(pos(3, 3, 100)),
+				bm(pos(1, 5, 100), pos(3, 4, 100)),
+			},
+			mask: maskZeroMid,
+			want: []uint64{pos(3, 3, 100), pos(3, 4, 100)},
+		},
+		{
+			// a has 5 lo values at mid=1; b has 2 of them at mid=2.
+			// Only the 2 shared lo values survive on both sides — interleaved
+			// in the want slice in numerical order (which is also ToArray
+			// order): (mid=1, lo=2), (mid=1, lo=4), (mid=2, lo=2), (mid=2, lo=4).
+			name: "many lo values: only co-present lo values survive",
+			inputs: []*Bitmap{
+				bm(pos(1, 1, 1), pos(1, 1, 2), pos(1, 1, 3), pos(1, 1, 4), pos(1, 1, 5)),
+				bm(pos(1, 2, 2), pos(1, 2, 4)),
+			},
+			mask: maskZeroMid,
+			want: []uint64{
+				pos(1, 1, 2), pos(1, 1, 4),
+				pos(1, 2, 2), pos(1, 2, 4),
+			},
+		},
+		{
+			// mask = ^0 → every value masks to itself → masked AND ≡ exact
+			// set intersection of the input bitmaps.
+			name:   "mask=^0 emits intersection of overlapping containers",
+			inputs: []*Bitmap{bm(10, 20, 30), bm(20, 30, 40)},
+			mask:   ^uint64(0),
+			want:   []uint64{20, 30},
+		},
+		{
+			// doc spans into the container key: doc=65537 sets bit 16 in v,
+			// which lives in the container key (bits 16-63). pos(1,1,65537)
+			// and pos(1,1,1) thus sit in DIFFERENT containers, and under
+			// maskZeroMid (which preserves the doc-high portion) they land in
+			// DIFFERENT masked groups despite sharing hi and mid.
+			name: "doc-high contributes to masked container key",
+			inputs: []*Bitmap{
+				bm(pos(1, 1, 65537), pos(1, 1, 1)),
+				bm(pos(1, 2, 65537)),
+			},
+			mask: maskZeroMid,
+			want: []uint64{pos(1, 1, 65537), pos(1, 2, 65537)},
+		},
+		{
+			// One masked group ((hi=1, mid=0)) but each side has multiple
+			// distinct exact keys in it, with partial overlap: K(1,1) is in
+			// both, K(1,2) only in a, K(1,3) only in b.
+			//   a positions: K(1,1)→{1,2}, K(1,2)→{3,4}.
+			//   b positions: K(1,1)→{2,5}, K(1,3)→{1,6}.
+			//   A_pos = {1,2,3,4}; B_pos = {1,2,5,6}; common_pos = {1,2}.
+			// Per key:
+			//   K(1,1) (both): (a OR b) AND common_pos = {1,2,5} AND {1,2} = {1,2}.
+			//   K(1,2) (a-only): {3,4} AND {1,2} = ∅ → skip.
+			//   K(1,3) (b-only): {1,6} AND {1,2} = {1} → emit.
+			name: "multiple containers per group, partial exact-key overlap",
+			inputs: []*Bitmap{
+				bm(pos(1, 1, 1), pos(1, 1, 2), pos(1, 2, 3), pos(1, 2, 4)),
+				bm(pos(1, 1, 2), pos(1, 1, 5), pos(1, 3, 1), pos(1, 3, 6)),
+			},
+			mask: maskZeroMid,
+			want: []uint64{pos(1, 1, 1), pos(1, 1, 2), pos(1, 3, 1)},
+		},
+
+		// --- N-ary cases (ported from the old chained tests, now direct
+		// CopresenceByMask calls). -----------------------------------------
+		{
+			name: "three-way: all inputs share single co-present group",
+			inputs: []*Bitmap{
+				bm(pos(1, 1, 5)),
+				bm(pos(1, 2, 5)),
+				bm(pos(1, 3, 5)),
+			},
+			mask: maskZeroMid,
+			want: []uint64{pos(1, 1, 5), pos(1, 2, 5), pos(1, 3, 5)},
+		},
+		{
+			name: "three-way: one input misses the group → empty",
+			inputs: []*Bitmap{
+				bm(pos(1, 1, 5)),
+				bm(pos(1, 2, 5)),
+				bm(pos(2, 3, 5)),
+			},
+			mask: maskZeroMid,
+			want: []uint64{},
+		},
+		{
+			name: "three-way: two distinct groups, all inputs contribute",
+			inputs: []*Bitmap{
+				bm(pos(1, 1, 5), pos(2, 1, 5)),
+				bm(pos(1, 2, 5), pos(2, 2, 5)),
+				bm(pos(1, 3, 5), pos(2, 3, 5)),
+			},
+			mask: maskZeroMid,
+			want: []uint64{
+				pos(1, 1, 5), pos(1, 2, 5), pos(1, 3, 5),
+				pos(2, 1, 5), pos(2, 2, 5), pos(2, 3, 5),
+			},
+		},
+		{
+			// Group (hi=1) is in all 3; group (hi=2) is in inputs 1+2 but
+			// missing from input 3 → drops out during the AND fold.
+			name: "three-way: only the fully co-present group survives",
+			inputs: []*Bitmap{
+				bm(pos(1, 1, 5), pos(2, 1, 5)),
+				bm(pos(1, 2, 5), pos(2, 2, 5)),
+				bm(pos(1, 3, 5)),
+			},
+			mask: maskZeroMid,
+			want: []uint64{pos(1, 1, 5), pos(1, 2, 5), pos(1, 3, 5)},
+		},
+		{
+			// Five-way intersection. Group (hi=1) is in all five → emits;
+			// group (hi=2) is only in the first four → drops out at the fifth.
+			name: "five-way: only fully co-present group survives",
+			inputs: []*Bitmap{
+				bm(pos(1, 1, 5), pos(2, 1, 5)),
+				bm(pos(1, 2, 5), pos(2, 2, 5)),
+				bm(pos(1, 3, 5), pos(2, 3, 5)),
+				bm(pos(1, 4, 5), pos(2, 4, 5)),
+				bm(pos(1, 5, 5)),
+			},
+			mask: maskZeroMid,
+			want: []uint64{
+				pos(1, 1, 5), pos(1, 2, 5), pos(1, 3, 5),
+				pos(1, 4, 5), pos(1, 5, 5),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runBoth(t, tt.inputs, tt.mask, func(t *testing.T, got *Bitmap) {
+				require.Equal(t, tt.want, got.ToArray())
+			})
+		})
+	}
+
+	t.Run("mixed array and bitmap containers in same group", func(t *testing.T) {
+		// Force a bitmap container in input 0 by populating one container
+		// with thousands of positions; input 1 uses a small array container
+		// for the same masked group. Exercises array/bitmap interop in the
+		// OR/AND container ops triggered by the algorithm.
+		aVals := make([]uint64, 3000)
+		for i := range aVals {
+			aVals[i] = pos(1, 1, uint64(i))
+		}
+		inputs := []*Bitmap{bm(aVals...), bm(pos(1, 2, 100), pos(1, 2, 2000), pos(1, 2, 9999))}
+
+		// A_pos = {0..2999}; B_pos = {100, 2000, 9999}; common_pos = {100, 2000}.
+		// 9999 is outside A's range, so it doesn't survive.
+		want := []uint64{
+			pos(1, 1, 100), pos(1, 1, 2000),
+			pos(1, 2, 100), pos(1, 2, 2000),
+		}
+		runBoth(t, inputs, maskZeroMid, func(t *testing.T, got *Bitmap) {
+			require.Equal(t, want, got.ToArray())
+		})
+	})
+
+	t.Run("wide gap between common masked keys exercises galloping", func(t *testing.T) {
+		// inputs[0] has 200 distinct masked groups (hi=1..200); inputs[1]
+		// has just the last one. The entry-walk's max-key advance must
+		// skip past 199 of inputs[0]'s entries — linear advance would step
+		// 199 times, while galloping reaches the target in O(log 199) ≈ 8
+		// steps. Correctness is what's checked here; the gallop path is
+		// exercised regardless.
+		aVals := make([]uint64, 200)
+		for i := range aVals {
+			hi := uint64(i + 1)
+			aVals[i] = pos(hi, 1, hi)
+		}
+		inputs := []*Bitmap{bm(aVals...), bm(pos(200, 1, 200))}
+
+		want := []uint64{pos(200, 1, 200)}
+		runBoth(t, inputs, maskZeroMid, func(t *testing.T, got *Bitmap) {
+			require.Equal(t, want, got.ToArray())
+		})
+	})
+}
+
+func TestCopresenceByMaskProperties(t *testing.T) {
+	pos := func(hi, mid, lo uint64) uint64 {
+		return (hi << 50) | (mid << 36) | lo
+	}
+	const maskZeroMid uint64 = ^(uint64(0x3FFF) << 36)
+
+	bm := func(values ...uint64) *Bitmap {
+		b := NewBitmap()
+		b.SetMany(values)
+		return b
+	}
+
+	t.Run("commutative across argument order (N=2)", func(t *testing.T) {
+		a := bm(pos(1, 1, 1), pos(2, 1, 1))
+		b := bm(pos(1, 2, 1), pos(2, 2, 1))
+
+		ab := CopresenceByMask([]*Bitmap{a, b}, maskZeroMid).ToArray()
+		ba := CopresenceByMask([]*Bitmap{b, a}, maskZeroMid).ToArray()
+		require.Equal(t, ab, ba)
+	})
+
+	t.Run("permutation-invariant across argument order (N=3)", func(t *testing.T) {
+		// For inputs with non-empty n-way co-presence, every permutation of
+		// the slice must yield the same value set. The algorithm's cursor
+		// initialization is order-sensitive but the result is not.
+		a := bm(pos(1, 1, 5), pos(2, 1, 5))
+		b := bm(pos(1, 2, 5), pos(3, 2, 5))
+		c := bm(pos(1, 3, 5), pos(2, 3, 5))
+
+		perms := [][]*Bitmap{
+			{a, b, c}, {a, c, b}, {b, a, c}, {b, c, a}, {c, a, b}, {c, b, a},
+		}
+		var first []uint64
+		for i, p := range perms {
+			got := CopresenceByMask(p, maskZeroMid).ToArray()
+			if i == 0 {
+				first = got
+				continue
+			}
+			require.Equal(t, first, got, "permutation %d differed", i)
+		}
+	})
+
+	t.Run("idempotent: CopresenceByMask([a, a], m) preserves a", func(t *testing.T) {
+		a := bm(pos(1, 1, 1), pos(2, 5, 1), pos(3, 9, 2))
+
+		got := CopresenceByMask([]*Bitmap{a, a}, maskZeroMid).ToArray()
+		require.Equal(t, a.ToArray(), got)
+	})
+
+	t.Run("matches A.Masked(m).And(B.Masked(m)) on co-presence", func(t *testing.T) {
+		// The result's masked image must equal the explicit
+		// A.Masked(m).And(B.Masked(m)) reference.
+		a := bm(
+			pos(1, 1, 1), pos(1, 1, 2), pos(2, 1, 1),
+			pos(1, 1, 100), pos(3, 9, 100),
+		)
+		b := bm(
+			pos(1, 2, 1), pos(1, 3, 2), pos(2, 7, 1),
+			pos(1, 4, 200), pos(5, 0, 100),
+		)
+
+		want := a.Masked(maskZeroMid).And(b.Masked(maskZeroMid))
+		got := CopresenceByMask([]*Bitmap{a, b}, maskZeroMid).Masked(maskZeroMid)
+
+		require.Equal(t, want.ToArray(), got.ToArray())
+	})
+
+	t.Run("mask=^0 reduces to set intersection", func(t *testing.T) {
+		a := bm(10, 20, 30, 40)
+		b := bm(20, 30, 50)
+
+		got := CopresenceByMask([]*Bitmap{a, b}, ^uint64(0)).ToArray()
+		require.Equal(t, []uint64{20, 30}, got)
+	})
+}
+
+func TestCopresenceByMaskToBuf(t *testing.T) {
+	// TestCopresenceByMask runs every table case through both
+	// CopresenceByMask and CopresenceByMaskToBuf, so result-correctness is
+	// covered there. The subtests below verify ToBuf-specific behaviour
+	// that the unified table can't observe.
+	pos := func(hi, mid, lo uint64) uint64 {
+		return (hi << 50) | (mid << 36) | lo
+	}
+	const maskZeroMid uint64 = ^(uint64(0x3FFF) << 36)
+
+	bm := func(values ...uint64) *Bitmap {
+		b := NewBitmap()
+		b.SetMany(values)
+		return b
+	}
+
+	t.Run("no allocation when buffer is large enough", func(t *testing.T) {
+		// With a generously-sized buffer, the result bitmap's data slice
+		// should never need to grow — capInBytes stays at the input buffer's
+		// original capacity.
+		inputs := []*Bitmap{
+			bm(pos(1, 1, 5), pos(2, 1, 5), pos(3, 1, 5)),
+			bm(pos(1, 2, 5), pos(2, 2, 5)),
+			bm(pos(1, 3, 5)),
+		}
+		bufBytes := 64 * 1024
+		buf := make([]byte, bufBytes)
+		got := CopresenceByMaskToBuf(inputs, maskZeroMid, buf)
+
+		require.Greater(t, got.GetCardinality(), 0)
+		require.Equal(t, bufBytes, got.capInBytes(),
+			"result cap should match the input buffer cap when no growth occurred")
+	})
+
+	t.Run("single input is cloned into buf, not aliased", func(t *testing.T) {
+		// Single-input short-circuit returns a Clone-backed-by-buf. Verify
+		// the result is independent of the source.
+		a := bm(pos(1, 1, 5), pos(2, 7, 9))
+		got := CopresenceByMaskToBuf([]*Bitmap{a}, maskZeroMid, make([]byte, 4096))
+		require.Equal(t, a.ToArray(), got.ToArray())
+		got.Set(pos(99, 0, 0))
+		require.False(t, a.Contains(pos(99, 0, 0)), "result must be a clone, not aliased")
+	})
+
+	t.Run("undersized buf still produces correct result (auto-grows)", func(t *testing.T) {
+		// Pass a tiny buffer; the bitmap internally allocates more space.
+		// Result correctness is preserved.
+		inputs := []*Bitmap{
+			bm(pos(1, 1, 1), pos(1, 1, 2)),
+			bm(pos(1, 2, 1), pos(1, 2, 2)),
+		}
+		got := CopresenceByMaskToBuf(inputs, maskZeroMid, make([]byte, 8))
+		expected := CopresenceByMask(inputs, maskZeroMid)
+		require.Equal(t, expected.ToArray(), got.ToArray())
 	})
 }


### PR DESCRIPTION
## Motivation                                                                                                           

  Weaviate's nested-filter executor needs every value `v` across N operand bitmaps such that `(v & mask)` is present in **every** operand's masked image — preserving original (unmasked) `v` in the result. The naive expression `bms[0].Masked(m).And(bms[1].Masked(m))...` allocates N intermediate bitmaps and walks each input multiple times; chained calls compound that cost.                                                                                                     
                                                                                                                            
  ## Approach                                                                                                             
                                                                                                                            
  **`CopresenceByMask(bms, mask)`** — single-pass N-ary implementation. Decomposes the mask into `mask_high` (container key bits) and `mask_low` (found via multi-pointer max-key walk with galloping), AND-folds the per-input position unions (smallest first, with early break-on-empty), then emits each unique original key as `OR_i(bms[i][K]) AND common_pos`.                                                                                         
                                                                                                                            
  **`CopresenceByMaskToBuf(bms, mask, buf)`** — same algorithm; result bitmap is backed by the caller-supplied buffer. Safe upper bound: `sum_i bms[i].LenInBytes()`. Under-sized buffers still produce a correct result (the bitmap auto-grows), they just don't elide the allocation.                                                     
                                                                                                                          
  Three `maxContainerSize` scratch buffers cover all phases (pos accumulation, AND fold, per-key merge, final filter) by reusing the "spare" buffer returned by `orPositionsInGroup` for the emit-phase filter target.                                                                                                            
                
  ## Key areas for review                                                                                                   
                                                                                                                          
  - `bitmap_opt.go:nextCommonGroup` — multi-pointer max-key walk; re-find-max loop converges because cursors only move forward.                                                         
  - `bitmap_opt.go:orPositionsInGroup` — returns `(result, spare)`; the spare buffer is reused downstream as part of the 3-buffer reuse.                                                        
  - `bitmap_opt.go:emitGroupFilteredN` — the per-key OR's load-bearing invariant is that `mergeFallback` post-OR-phase never aliases `merged`, so the final AND can write into it as the filter target.                                                      
  - **Mask shape requirement** (`mask & 0xFFFF == 0xFFFF`) is documented, not runtime-enforced. Other shapes silently produce wrong results.                                                      
                                                                                                                            
  ## Testing                                                                                                                
                                                                                                                            
  `TestCopresenceByMask` is one unified table run through both call paths (`plain` and `ToBuf`) via a `runBoth` helper. Cases cover edge inputs (empty slice, single input, any-empty-among-many), the original binary scenarios, three- and five-way N-ary, plus structural stresses (mixed array/bitmap containers forcing the swap path, a 200-group "wide gap" exercising galloping). `TestCopresenceByMaskProperties` covers commutativity, permutation invariance, idempotence, and equivalence to `A.Masked(m).And(B.Masked(m))` on the masked image.                                                                       
  `TestCopresenceByMaskToBuf` covers ToBuf-specific behaviour: no-growth verification via `capInBytes()`, single-input clone-into-buf (non-aliased), and undersized-buf auto-grow.  