### PR TITLE
feature: FloorMasked() and FloorMaskedToBuf() — grouped predecessor (floor) query

### DIFF
--- a/benchmark_floor_test.go
+++ b/benchmark_floor_test.go
@@ -1,0 +1,86 @@
+package sroar
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// buildFloorMaskedInputs constructs vals and candidates bitmaps with values
+// encoded as (aux << 36) | doc, with aux in bits 36..63 and doc in bits 0..35.
+// mask = 0x0000000FFFFFFFFF (mask_low16 = 0xFFFF) groups values by doc.
+//
+// This shape — high bits encode an auxiliary identifier the mask strips,
+// low bits encode the grouping key — exercises the non-contiguous-high
+// mask path that FloorMasked is designed for.
+//
+// numAux controls how many aux IDs share each doc (= how often the
+// membership lookup finds a non-trivial match path); numDocs is the
+// distinct-doc count (= number of masked groups). totalBits is the
+// approximate total bit count per bitmap; bits are spread roughly evenly
+// across (aux, doc) pairs.
+func buildFloorMaskedInputs(seed int64, numAux, numDocs, totalBits int) (vals, candidates *Bitmap, mask uint64) {
+	mask = 0x0000000FFFFFFFFF
+	rnd := rand.New(rand.NewSource(seed))
+	vals = NewBitmap()
+	candidates = NewBitmap()
+	for i := 0; i < totalBits; i++ {
+		aux := uint64(rnd.Intn(numAux))
+		doc := uint64(rnd.Intn(numDocs))
+		vals.Set((aux << 36) | doc)
+	}
+	for i := 0; i < totalBits; i++ {
+		aux := uint64(rnd.Intn(numAux))
+		doc := uint64(rnd.Intn(numDocs))
+		candidates.Set((aux << 36) | doc)
+	}
+	return vals, candidates, mask
+}
+
+type floorBenchCase struct {
+	name      string
+	numAux    int
+	numDocs   int
+	totalBits int
+}
+
+var floorBenchCases = []floorBenchCase{
+	// Typical scale: 1M bits, ~5 aux levels, 200K groups.
+	{"Realistic", 5, 200_000, 1_000_000},
+
+	// Dense per group: fewer groups, more bits each.
+	{"Dense", 10, 10_000, 1_000_000},
+
+	// Sparse per group: many groups, few bits per group.
+	{"Sparse", 5, 2_000_000, 500_000},
+
+	// Small: tip of the small-input regime.
+	{"Small", 4, 100, 1_000},
+}
+
+func BenchmarkFloorMasked(b *testing.B) {
+	for _, tc := range floorBenchCases {
+		vals, candidates, mask := buildFloorMaskedInputs(20260622, tc.numAux, tc.numDocs, tc.totalBits)
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				FloorMasked(vals, candidates, mask)
+			}
+		})
+	}
+}
+
+func BenchmarkFloorMaskedToBuf(b *testing.B) {
+	for _, tc := range floorBenchCases {
+		vals, candidates, mask := buildFloorMaskedInputs(20260622, tc.numAux, tc.numDocs, tc.totalBits)
+		// Size buf upper-bounded by candidates' storage — the result can
+		// never exceed candidates in container count or bits.
+		warm := FloorMasked(vals, candidates, mask)
+		buf := make([]byte, len(warm.data)*2+4096)
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				FloorMaskedToBuf(vals, candidates, mask, buf)
+			}
+		})
+	}
+}

--- a/bitmap_floor.go
+++ b/bitmap_floor.go
@@ -1,0 +1,454 @@
+package sroar
+
+import (
+	"math/bits"
+)
+
+// FloorMasked returns a new bitmap holding, for each bit v in vals, the
+// greatest bit c ≤ v in candidates such that (v & mask) == (c & mask). Bits
+// in vals whose group has no predecessor in candidates contribute nothing.
+// The result is naturally deduplicated (multiple v's mapping to the same c
+// emit c once).
+//
+// The mask defines a grouping over values: two values belong to the same group
+// iff they agree under mask. Within a group, the operation is a classic
+// predecessor (floor) query; groups are independent.
+//
+// The lowest 16 bits of mask are always zeroed: they correspond to the
+// within-container offset, not the container key, and grouping is only
+// meaningful at container-key granularity.
+//
+// Neither input is modified.
+func FloorMasked(vals, candidates *Bitmap, mask uint64) *Bitmap {
+	return floorMaskedInto(vals, candidates, mask, NewBitmap())
+}
+
+// FloorMaskedToBuf is like [FloorMasked] but uses the provided byte slice as
+// the underlying buffer for the result bitmap, avoiding the result's heap
+// allocation when the buffer is large enough.
+//
+// Sizing guidance: a safe upper bound is candidates.LenInBytes() — the result
+// has at most one bit per bit of candidates in matching groups, and at most
+// one result container per candidates container, so it can never exceed
+// candidates in storage.
+func FloorMaskedToBuf(vals, candidates *Bitmap, mask uint64, buf []byte) *Bitmap {
+	return floorMaskedInto(vals, candidates, mask, NewBitmapToBuf(buf))
+}
+
+func floorMaskedInto(vals, candidates *Bitmap, mask uint64, res *Bitmap) *Bitmap {
+	if vals.IsEmpty() || candidates.IsEmpty() {
+		return res
+	}
+
+	// Precondition (caller commitment): mask & 0xFFFF == 0xFFFF. The per-bit
+	// step is a membership test of vals' low 16 bits against the matching
+	// candidates container — i.e. equality is the only candidate within a
+	// container-key group. Other low-16 mask shapes are undefined; the impl
+	// treats them as 0xFFFF.
+	mask &= 0xFFFFFFFFFFFF0000
+
+	// Masked keys are not guaranteed to be ascending in raw-key order — for
+	// non-contiguous-high masks (e.g. 0x0000FFFFFFFF0000, common when the
+	// high bits encode an auxiliary identifier that the mask strips), two
+	// raw keys k1 < k2 can have k1&mask > k2&mask. So we cannot walk masked
+	// groups by stepping through raw keys; we have to sort entries by
+	// (maskedKey, originalKey) first.
+	aEntries := buildKeyedMaskedEntries(vals, mask)
+	bEntries := buildKeyedMaskedEntries(candidates, mask)
+
+	res.expandConditionally(len(bEntries), 0)
+
+	// Find the largest masked-group size in bEntries — we'll allocate
+	// per-bucket storage sized to this. The buckets are reused across
+	// every processFloorGroup call (one alloc for the whole FloorMasked
+	// call), so sizing to the largest group ensures it's always enough.
+	maxBGroupSize := 0
+	for i := 0; i < len(bEntries); {
+		j := i + 1
+		for j < len(bEntries) && bEntries[j].maskedKey == bEntries[i].maskedKey {
+			j++
+		}
+		if j-i > maxBGroupSize {
+			maxBGroupSize = j - i
+		}
+		i = j
+	}
+	if maxBGroupSize == 0 {
+		return res
+	}
+
+	// arrBuf: stack-allocated scratch for floorWriteBucket's array-form
+	// serialization (only used on the small-card flush path).
+	var arrBuf [maxContainerSize]uint16
+
+	// Per-bucket storage, one bucket per candidates entry in the current
+	// masked group. The key insight that justifies this design:
+	// bGroup[i].originalKey is globally unique across every processFloorGroup
+	// call (each candidates container has a unique container key), so each
+	// masked-group's flush writes to a fresh key in res. No OR-merge ever
+	// fires, and bucketing within one processFloorGroup means each vals
+	// container's non-monotonic emit pattern (cache hits scattered across
+	// candidates entries) gets sorted by bucket into N small buffers —
+	// N flushes per group instead of N × vals_container_card.
+	//
+	// bucketBufs is a single contiguous []uint16, viewed as maxBGroupSize
+	// bitmap-form buffers of size maxContainerSize each. bucketStates tracks
+	// per-bucket card/minWord/maxWord for compact flush.
+	bucketBufs := make([]uint16, maxBGroupSize*maxContainerSize)
+	bucketStates := make([]floorBucketState, maxBGroupSize)
+
+	ai, bi := 0, 0
+	an, bn := len(aEntries), len(bEntries)
+
+	for ai < an && bi < bn {
+		ag := aEntries[ai].maskedKey
+		bg := bEntries[bi].maskedKey
+
+		if ag < bg {
+			ai++
+			for ai < an && aEntries[ai].maskedKey == ag {
+				ai++
+			}
+			continue
+		}
+		if ag > bg {
+			bi++
+			for bi < bn && bEntries[bi].maskedKey == bg {
+				bi++
+			}
+			continue
+		}
+
+		aiEnd := ai + 1
+		for aiEnd < an && aEntries[aiEnd].maskedKey == ag {
+			aiEnd++
+		}
+		biEnd := bi + 1
+		for biEnd < bn && bEntries[biEnd].maskedKey == bg {
+			biEnd++
+		}
+
+		processFloorGroup(vals, candidates, aEntries[ai:aiEnd], bEntries[bi:biEnd], res, bucketBufs, bucketStates, arrBuf[:])
+		ai = aiEnd
+		bi = biEnd
+	}
+
+	return res
+}
+
+// floorCacheHalf is the number of cache slots in each half (cacheLo / cacheHi).
+// The full per-low-bit cache spans maxCardinality (= 65536) slots — one per
+// possible low-16-bit value within a container; we split in two so each half
+// fits under Go's MaxStackVarSize (128 KB) and stack-allocates. Each half is
+// maxCardinality/2 * 4 bytes = 128 KB exactly.
+const floorCacheHalf = maxCardinality / 2
+
+// floorArrMaxCard is the cardinality threshold at which floorWriteBucket
+// switches from array-form to bitmap-form output. Above this, the result
+// container is written as a full bitmap (maxContainerSize uint16s)
+// regardless of how it would fit as an array.
+//
+// Set to half of bitmapDataWords (= 2048), matching sroar's stepSize
+// convention — sroar's organic array-container growth tops out at size
+// 2048 (= ~2044 elements) before promoting to bitmap.
+const floorArrMaxCard = bitmapDataWords / 2
+
+// floorBucketState tracks per-bucket accumulation state inside one
+// processFloorGroup call. Each bucket holds the emitted bits destined for a
+// single b entry's originalKey (= the eventual key in res). card / minWord /
+// maxWord support the bucket's flush at end-of-group: card chooses array-
+// vs bitmap-form output, minWord/maxWord bound the array-form scan and the
+// targeted clear of the bucket's scratch.
+//
+// Field widths reflect actual value ranges:
+//   - card: 0..maxCardinality (= 65536) → uint32.
+//   - minWord: 0..bitmapDataWords (= 4096; the upper bound is the reset
+//     sentinel for "no bits set yet") → uint16.
+//   - maxWord: 0..bitmapDataWords-1 (= 4095) → uint16. Reset to 0; the
+//     `if wordIdx > state.maxWord` update leaves maxWord at 0 when the
+//     first bit lands in word 0, which is the correct answer (max IS 0).
+type floorBucketState struct {
+	card    uint32
+	minWord uint16
+	maxWord uint16
+}
+
+// processFloorGroup handles one masked group: for every bit v in the vals
+// entries of this group, find the greatest bit c ≤ v in the candidates
+// entries of this group and emit c into res. Entries in aGroup and bGroup
+// share the same masked container key and are sorted ascending by
+// originalKey; within a container, values are sorted ascending.
+// buildKeyedMaskedEntries has already stripped empty containers.
+//
+// Algorithm: parallel walk over a flat 65536-slot per-low-bit cache (split
+// across two stack-allocated [32768]uint32 halves to fit under Go's
+// MaxStackVarSize = 128 KB per explicit variable), with per-bucket
+// accumulation.
+//
+//   - As candidates containers are processed, floorUpdateCache writes
+//     (bi+1) into the right cache half for every set low-16-bit value in
+//     the container. The +1 keeps 0 as a sentinel for "no candidates
+//     entry has covered this low value yet".
+//   - As vals containers are processed, emitFloorsBucketed looks up the
+//     cache for each set bit's low-16 value and, if the slot is non-zero,
+//     writes the set bit into bucket[slot-1] inside bucketBufs.
+//   - At end of the masked group, each non-empty bucket is flushed once
+//     via floorWriteBucket. No OR-merge ever fires: each candidates
+//     entry's originalKey is unique across every processFloorGroup call,
+//     so every flush hits a fresh key in res.
+//
+// Why bucketing: an alternative design (single accumulator, flush on
+// destination-key change) would suffer O(N × vals_container_card) flushes
+// per vals container under the cache algorithm's non-monotonic emit
+// pattern (a single vals container can resolve different low values to
+// different candidates entries, and consecutive vals containers can
+// re-resolve to earlier candidates entries → frequent destination changes
+// → frequent flush → repeated OR-merges into the same res container).
+// Bucketing classifies emits by destination key on the fly and flushes
+// each destination once, dropping flush count from O(card) to O(|bGroup|)
+// per vals container.
+//
+// Tie-break: at equal originalKey, the candidates entry is processed
+// first so the vals entry sees the cache updates before its own emission.
+// This covers the case where a bit in vals is its own floor because that
+// same value also appears in candidates at the same container key.
+//
+// Go zero-inits the cache halves per call so sentinel-0 = "unset" without
+// explicit clear. The closure-free signatures of floorUpdateCache and
+// emitFloorsBucketed are load-bearing: a closure capturing the cache
+// halves would force them to the heap. See go build -gcflags='-m=2' as a
+// merge-gate verification.
+func processFloorGroup(
+	a, b *Bitmap,
+	aGroup, bGroup []keyedMaskedEntry,
+	res *Bitmap,
+	bucketBufs []uint16,
+	bucketStates []floorBucketState,
+	arrBuf []uint16,
+) {
+	var cacheLo, cacheHi [floorCacheHalf]uint32
+
+	nBuckets := len(bGroup)
+
+	// Reset per-bucket state for this masked group. bucketBufs's touched
+	// words are cleared at the end of the previous group's flush (see the
+	// flush loop below), so here we only need to reset the scalar state.
+	for i := 0; i < nBuckets; i++ {
+		bucketStates[i].card = 0
+		bucketStates[i].minWord = bitmapDataWords
+		bucketStates[i].maxWord = 0
+	}
+
+	ai, bi := 0, 0
+	an, bn := len(aGroup), len(bGroup)
+
+	for ai < an && bi < bn {
+		if bGroup[bi].originalKey <= aGroup[ai].originalKey {
+			bc := b.getContainer(bGroup[bi].offset)
+			floorUpdateCache(bc, &cacheLo, &cacheHi, uint32(bi)+1)
+			bi++
+		} else {
+			ac := a.getContainer(aGroup[ai].offset)
+			emitFloorsBucketed(ac, &cacheLo, &cacheHi, bucketBufs, bucketStates)
+			ai++
+		}
+	}
+	// Drain remaining vals entries — the cache already holds the latest
+	// candidates entry for every low value that ever appeared in this
+	// group's candidates entries. Remaining candidates entries can't
+	// affect emission since no vals entry is left.
+	for ai < an {
+		ac := a.getContainer(aGroup[ai].offset)
+		emitFloorsBucketed(ac, &cacheLo, &cacheHi, bucketBufs, bucketStates)
+		ai++
+	}
+
+	// Flush each non-empty bucket to res. Each destination key is unique
+	// across the whole call, so every flush is a fresh container write —
+	// no OR-merge needed.
+	si := int(startIdx)
+	for k := 0; k < nBuckets; k++ {
+		state := &bucketStates[k]
+		if state.card == 0 {
+			continue
+		}
+		bucketStart := k * maxContainerSize
+		bucketBuf := bucketBufs[bucketStart : bucketStart+maxContainerSize]
+		floorWriteBucket(res, bGroup[k].originalKey, bucketBuf, state.card, state.minWord, state.maxWord, arrBuf)
+		// Clear only the words this bucket touched so the next masked group
+		// (which reuses bucketBufs) starts from a clean slate. The rest of
+		// bucketBufs is zero from the initial make().
+		clear(bucketBuf[si+int(state.minWord) : si+int(state.maxWord)+1])
+	}
+}
+
+// floorUpdateCache writes slot into the right cache half for every set bit's
+// low-16 value in c (a candidates container). Dispatches on container type.
+// For bitmap containers, the outer uint64-stride loop skips 4 uint16 words
+// at a time over empty regions; because each uint64 spans 64 consecutive
+// low values, all bits in one uint64 land in the same cache half — so the
+// cache-half dispatch happens once per uint64, not per bit.
+func floorUpdateCache(c []uint16, cacheLo, cacheHi *[floorCacheHalf]uint32, slot uint32) {
+	si := int(startIdx)
+	if c[indexType] == typeArray {
+		n := getCardinality(c)
+		for i := 0; i < n; i++ {
+			low := c[si+i]
+			if low < floorCacheHalf {
+				cacheLo[low] = slot
+			} else {
+				cacheHi[low-floorCacheHalf] = slot
+			}
+		}
+		return
+	}
+	c64 := uint16To64SliceUnsafe(c[si:])
+	const halfStride = bitmapDataUint64s / 2
+	for j := 0; j < bitmapDataUint64s; j++ {
+		if c64[j] == 0 {
+			continue
+		}
+		cache := cacheLo
+		var baseAdjust uint16
+		if j >= halfStride {
+			cache = cacheHi
+			baseAdjust = floorCacheHalf
+		}
+		for k := 0; k < 4; k++ {
+			w := j*4 + k
+			word := c[si+w]
+			if word == 0 {
+				continue
+			}
+			base := uint16(w*16) - baseAdjust
+			for word != 0 {
+				pos := bits.LeadingZeros16(word)
+				word &^= 1 << uint(15-pos)
+				cache[base+uint16(pos)] = slot
+			}
+		}
+	}
+}
+
+// emitFloorsBucketed looks up the cache for every set bit's low-16 value in c
+// (a vals container); if the slot is non-zero, sets the corresponding bit in
+// bucketBufs[(slot-1)*maxContainerSize ..] and updates that bucket's
+// card / minWord / maxWord. No emission to a shared accumulator — every bit
+// goes straight to its target bucket.
+//
+// Container-type dispatch mirrors floorUpdateCache; the bitmap path uses
+// the per-uint64 cache-half pick to keep per-bit overhead minimal.
+func emitFloorsBucketed(c []uint16, cacheLo, cacheHi *[floorCacheHalf]uint32, bucketBufs []uint16, bucketStates []floorBucketState) {
+	si := int(startIdx)
+	if c[indexType] == typeArray {
+		n := getCardinality(c)
+		for i := 0; i < n; i++ {
+			low := c[si+i]
+			var slot uint32
+			if low < floorCacheHalf {
+				slot = cacheLo[low]
+			} else {
+				slot = cacheHi[low-floorCacheHalf]
+			}
+			if slot == 0 {
+				continue
+			}
+			floorSetBucketBit(bucketBufs, bucketStates, int(slot-1), low)
+		}
+		return
+	}
+	c64 := uint16To64SliceUnsafe(c[si:])
+	const halfStride = bitmapDataUint64s / 2
+	for j := 0; j < bitmapDataUint64s; j++ {
+		if c64[j] == 0 {
+			continue
+		}
+		cache := cacheLo
+		var baseAdjust uint16
+		if j >= halfStride {
+			cache = cacheHi
+			baseAdjust = floorCacheHalf
+		}
+		for k := 0; k < 4; k++ {
+			w := j*4 + k
+			word := c[si+w]
+			if word == 0 {
+				continue
+			}
+			base := uint16(w*16) - baseAdjust
+			for word != 0 {
+				pos := bits.LeadingZeros16(word)
+				word &^= 1 << uint(15-pos)
+				cacheIdx := base + uint16(pos)
+				if slot := cache[cacheIdx]; slot != 0 {
+					floorSetBucketBit(bucketBufs, bucketStates, int(slot-1), cacheIdx+baseAdjust)
+				}
+			}
+		}
+	}
+}
+
+// floorSetBucketBit sets the bit for low in bucket bIdx and updates the
+// bucket's card / minWord / maxWord. Dedup is natural (setting the same
+// bit twice is a no-op but skips the card++).
+func floorSetBucketBit(bucketBufs []uint16, bucketStates []floorBucketState, bIdx int, low uint16) {
+	wordIdx := low >> 4
+	bufIdx := bIdx*maxContainerSize + int(startIdx) + int(wordIdx)
+	bit := bitmapMask[low&0xF]
+	if bucketBufs[bufIdx]&bit != 0 {
+		return
+	}
+	bucketBufs[bufIdx] |= bit
+	state := &bucketStates[bIdx]
+	state.card++
+	if wordIdx < state.minWord {
+		state.minWord = wordIdx
+	}
+	if wordIdx > state.maxWord {
+		state.maxWord = wordIdx
+	}
+}
+
+// floorWriteBucket writes a flushed bucket to res at the given key. The key
+// is always fresh in res (each b entry's originalKey is unique across the
+// whole FloorMasked call), so no OR-merge logic is needed. Chooses array-
+// form output for compact small-card containers (card ≤ floorArrMaxCard) and
+// bitmap-form for larger.
+//
+// arrBuf is the array-form serialization scratch (only touched on the
+// small-card path). bmpSrc is the bucket's bitmap-form buffer; the header
+// is set in place on the bitmap-form path.
+func floorWriteBucket(res *Bitmap, key uint64, bmpSrc []uint16, card uint32, minWord, maxWord uint16, arrBuf []uint16) {
+	si := int(startIdx)
+	var src []uint16
+	if card > floorArrMaxCard {
+		bmpSrc[indexSize] = maxContainerSize
+		bmpSrc[indexType] = typeBitmap
+		setCardinality(bmpSrc, int(card))
+		src = bmpSrc
+	} else {
+		// Materialize array form by scanning only the touched word range.
+		idx := si
+		for w := minWord; w <= maxWord; w++ {
+			word := bmpSrc[si+int(w)]
+			if word == 0 {
+				continue
+			}
+			base := w * 16
+			for word != 0 {
+				pos := bits.LeadingZeros16(word)
+				word &^= 1 << uint(15-pos)
+				arrBuf[idx] = base + uint16(pos)
+				idx++
+			}
+		}
+		arrBuf[indexSize] = uint16(idx)
+		arrBuf[indexType] = typeArray
+		setCardinality(arrBuf, int(card))
+		src = arrBuf[:idx]
+	}
+	res.expandConditionally(0, len(src))
+	off := res.newContainerNoClr(uint16(len(src)))
+	copy(res.data[off:], src)
+	res.setKey(key, off)
+}

--- a/bitmap_floor_test.go
+++ b/bitmap_floor_test.go
@@ -1,0 +1,287 @@
+package sroar
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// encode places `high` in the upper (64-k) bits and `low` in the lower k bits.
+func encode(high, low uint64, k uint) uint64 { return (high << k) | low }
+
+// bitmapOf is a small constructor so test bodies read as one expression per
+// bitmap instead of a Set loop.
+func bitmapOf(values ...uint64) *Bitmap {
+	bm := NewBitmap()
+	bm.SetMany(values)
+	return bm
+}
+
+func TestFloorMasked(t *testing.T) {
+	// Most cases use this mask: each container key is its own group.
+	// With mask & 0xFFFF == 0 the per-value step degenerates — every bit
+	// in vals that shares its container-key group with any candidates
+	// container will only emit when the bit's exact value (= same low
+	// 16 bits) is set in some matching candidates container. The
+	// surviving abstract cases are the ones whose expected output
+	// coincides with that membership semantic.
+	const mh = uint64(0xFFFFFFFFFFFF0000)
+
+	t.Run("empty vals", func(t *testing.T) {
+		res := FloorMasked(NewBitmap(), bitmapOf(encode(1, 50, 16)), mh)
+		require.Empty(t, res.ToArray())
+	})
+
+	t.Run("empty candidates", func(t *testing.T) {
+		res := FloorMasked(bitmapOf(encode(1, 100, 16)), NewBitmap(), mh)
+		require.Empty(t, res.ToArray())
+	})
+
+	t.Run("no floor in group", func(t *testing.T) {
+		vals := bitmapOf(encode(1, 50, 16))
+		candidates := bitmapOf(encode(1, 100, 16))
+		require.Empty(t, FloorMasked(vals, candidates, mh).ToArray())
+	})
+
+	t.Run("value is its own floor (value in candidates)", func(t *testing.T) {
+		vals := bitmapOf(encode(1, 100, 16))
+		candidates := bitmapOf(encode(1, 100, 16))
+		require.Equal(t, []uint64{encode(1, 100, 16)}, FloorMasked(vals, candidates, mh).ToArray())
+	})
+
+	t.Run("group isolation: numerically valid but wrong group", func(t *testing.T) {
+		// candidates' only bit is numerically smaller than vals', but in a
+		// different masked group → must not contribute.
+		vals := bitmapOf(encode(2, 100, 16))
+		candidates := bitmapOf(encode(1, 50, 16))
+		require.Empty(t, FloorMasked(vals, candidates, mh).ToArray())
+	})
+
+	t.Run("mask all-ones: membership regime, result is vals intersect candidates", func(t *testing.T) {
+		// With mask & 0xFFFF == 0xFFFF (here: all-ones), the per-value
+		// step is a membership test: a bit emits iff it's also in
+		// candidates (in its container-key group). So FloorMasked
+		// degenerates to vals ∩ candidates.
+		vals := bitmapOf(encode(1, 100, 16), encode(2, 200, 16), encode(3, 300, 16))
+		candidates := bitmapOf(encode(2, 200, 16), encode(4, 400, 16))
+		expected := []uint64{encode(2, 200, 16)}
+		require.Equal(t, expected, FloorMasked(vals, candidates, 0xFFFFFFFFFFFFFFFF).ToArray())
+	})
+
+	t.Run("idempotence: FloorMasked(x, x, mask) == x (set-equal)", func(t *testing.T) {
+		// Every bit in x is trivially a member of x, so the membership
+		// test emits it at its own container key. Result equals x
+		// set-wise.
+		x := NewBitmap()
+		for i := uint64(0); i < 200; i++ {
+			x.Set(encode(i%17, i*13, 16))
+		}
+		got := FloorMasked(x, x, mh).ToArray()
+		require.Equal(t, x.ToArray(), got)
+	})
+
+	t.Run("regression: same destination key flushed twice in one group", func(t *testing.T) {
+		// Under the membership semantic, different low values within a
+		// single vals container can resolve to different candidates
+		// entries — and a later vals container can re-resolve to an
+		// earlier candidates entry. The resulting destination-key emit
+		// sequence within one processFloorGroup call is non-monotonic
+		// (here: A, B, A). Under a historical single-accumulator design
+		// this triggered an OR-merge that orphaned the first flush's
+		// bit; the current per-bucket design dedups naturally.
+		//
+		// Verified trace (one masked group, mask = 0xFFFF):
+		//   vals container @0x3000000000 = {0x000A, 0x0014}
+		//     0x000A → cache hit at candidates @0x2000000000 → emit 0x200000000A
+		//     0x0014 → cache hit at candidates @0x1000000000 → emit 0x1000000014
+		//   vals container @0x4000000000 = {0x0018}
+		//     0x0018 → cache hit at candidates @0x2000000000 → emit 0x2000000018
+		// Destination-key sequence: A=0x2000000000, B=0x1000000000, A=0x2000000000.
+		vals := bitmapOf(0x300000000A, 0x3000000014, 0x4000000018)
+		candidates := bitmapOf(0x1000000014, 0x200000000A, 0x2000000018)
+		// ToArray returns sorted ascending; reorder accordingly.
+		expected := []uint64{0x1000000014, 0x200000000A, 0x2000000018}
+		require.Equal(t, expected, FloorMasked(vals, candidates, 0xFFFF).ToArray())
+	})
+
+	t.Run("regression: match more than one candidates container behind cursor", func(t *testing.T) {
+		// All four containers collapse into one masked group (mask &
+		// 0xFFFFFFFFFFFF0000 == 0). The membership regime applies
+		// because mask & 0xFFFF == 0xFFFF.
+		//
+		// vals has one bit with container key 0x7000000000 and low 0x14.
+		// candidates has three containers in this group:
+		//   c[0] at 0x2000000000 with {0x14}  ← only match for low 0x14
+		//   c[1] at 0x5000000000 with {0x0A}
+		//   c[2] at 0x6000000000 with {0x0A}
+		//
+		// All three are ≤ the vals key, so the cursor advances past all of
+		// them. An earlier impl tracked only the current candidates container
+		// and one step back, which left c[2] and c[1] in scope at emit
+		// time — both missing the match. The correct floor is c[0]'s
+		// 0x2000000014, which a backward walk over the group finds.
+		vals := bitmapOf(0x7000000014)
+		candidates := bitmapOf(0x2000000014, 0x500000000A, 0x600000000A)
+		expected := []uint64{0x2000000014}
+		require.Equal(t, expected, FloorMasked(vals, candidates, 0xFFFF).ToArray())
+	})
+}
+
+// TestFloorMaskedFixtures covers shape-based fixtures with a non-contiguous
+// mask. Encoding: position = (level << 36) | groupID. mask = 0x0000000FFFFFFFFF
+// groups by groupID: low 36 bits survive, top 28 are zeroed.
+//
+// Kept separate from TestFloorMasked because the mask shape is genuinely
+// different — after the impl's internal mask &= 0xFFFFFFFFFFFF0000, the
+// effective mask is 0x0000000FFFF0000 (bits 16..35 set), a non-contiguous
+// mask whose masked-key order does NOT follow raw-key order. These cases
+// exercise that path directly.
+func TestFloorMaskedFixtures(t *testing.T) {
+	const mask = uint64(0x0000000FFFFFFFFF)
+
+	cases := []struct {
+		name       string
+		vals       []uint64
+		candidates []uint64
+		want       []uint64
+	}{
+		// --- Single group (groupID = 10) ---
+		{
+			"three values mapping to two floors, single group",
+			[]uint64{0x300000000A, 0x400000000A, 0x600000000A},
+			[]uint64{0x200000000A, 0x500000000A},
+			[]uint64{0x200000000A, 0x500000000A},
+		},
+		{
+			"three values mapping to one far-below floor, single group",
+			[]uint64{0x300000000A, 0x400000000A, 0x600000000A},
+			[]uint64{0x100000000A},
+			[]uint64{0x100000000A},
+		},
+		{
+			"two values mapping to one far-below floor, single group",
+			[]uint64{0x200000000A, 0x500000000A},
+			[]uint64{0x100000000A},
+			[]uint64{0x100000000A},
+		},
+		{
+			"single value picks lower of two candidates",
+			[]uint64{0x300000000A},
+			[]uint64{0x200000000A, 0x500000000A},
+			[]uint64{0x200000000A},
+		},
+		{
+			"single value picks higher of two candidates",
+			[]uint64{0x600000000A},
+			[]uint64{0x200000000A, 0x500000000A},
+			[]uint64{0x500000000A},
+		},
+
+		// --- Multi group ---
+		{
+			// ToArray returns sorted ascending; expected reordered to match.
+			"two groups, each with multiple values and floors",
+			[]uint64{0x300000000A, 0x600000000A, 0x3000000014},
+			[]uint64{0x200000000A, 0x500000000A, 0x2000000014},
+			[]uint64{0x200000000A, 0x2000000014, 0x500000000A},
+		},
+		{
+			"two vals groups, only one has matching candidates",
+			[]uint64{0x300000000A, 0x3000000014},
+			[]uint64{0x200000000A},
+			[]uint64{0x200000000A},
+		},
+
+		// --- Multi-root within one group (groupID = 30) ---
+		{
+			"two floors same group, value at each picks its own",
+			[]uint64{0x200000001E, 0x500000001E},
+			[]uint64{0x100000001E, 0x400000001E},
+			[]uint64{0x100000001E, 0x400000001E},
+		},
+		{
+			"two value-levels above two floor roots, both lift fully",
+			[]uint64{0x300000001E, 0x600000001E},
+			[]uint64{0x100000001E, 0x400000001E},
+			[]uint64{0x100000001E, 0x400000001E},
+		},
+		{
+			"two values, two floors, single group",
+			[]uint64{0x300000001E, 0x600000001E},
+			[]uint64{0x200000001E, 0x500000001E},
+			[]uint64{0x200000001E, 0x500000001E},
+		},
+
+		// --- Edge cases ---
+		{
+			"value below the only floor in the group",
+			[]uint64{0x100000000A},
+			[]uint64{0x200000000A},
+			nil,
+		},
+		{
+			"idempotence",
+			[]uint64{0x200000000A, 0x500000000A},
+			[]uint64{0x200000000A, 0x500000000A},
+			[]uint64{0x200000000A, 0x500000000A},
+		},
+		{
+			// The value is numerically larger than a smaller candidate
+			// from a different group, but the cross-group candidate must
+			// be rejected on group grounds.
+			"cross-group isolation (numerically tempting)",
+			[]uint64{0x3000000014},
+			[]uint64{0x100000000A, 0x1000000014},
+			[]uint64{0x1000000014},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vals := bitmapOf(tc.vals...)
+			candidates := bitmapOf(tc.candidates...)
+			got := FloorMasked(vals, candidates, mask).ToArray()
+			if tc.want == nil {
+				require.Empty(t, got)
+				return
+			}
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestFloorMaskedToBufAllocs measures the algorithm's allocation count under
+// a pre-sized buffer. Each call currently allocates: the *Bitmap header that
+// NewBitmapToBuf returns, two entries slices from buildKeyedMaskedEntries
+// (one per input — necessary for correctness when the mask isn't contiguous-
+// high; see comments in floorMaskedInto), and the two bucket storage slices
+// (bucketBufs + bucketStates) used for the per-bucket flush. That's 5
+// allocs/op.
+//
+// Reducing further would require pooling the bucket storage. Tracking the
+// actual count makes accidental regressions visible.
+func TestFloorMaskedToBufAllocs(t *testing.T) {
+	rnd := rand.New(rand.NewSource(20260619))
+	vals := NewBitmap()
+	candidates := NewBitmap()
+	for i := 0; i < 10_000; i++ {
+		g := uint64(rnd.Intn(100))
+		o := uint64(rnd.Intn(1 << 16))
+		vals.Set((g << 16) | o)
+		candidates.Set((g << 16) | o>>1)
+	}
+	const m = uint64(0xFFFFFFFFFFFF0000)
+
+	buf := make([]byte, 1<<22) // 4MB — comfortably exceeds the result size
+
+	// Pre-warm any one-time setup.
+	_ = FloorMaskedToBuf(vals, candidates, m, buf)
+
+	allocs := testing.AllocsPerRun(50, func() {
+		_ = FloorMaskedToBuf(vals, candidates, m, buf)
+	})
+	t.Logf("FloorMaskedToBuf allocs/op = %.2f", allocs)
+	require.LessOrEqual(t, allocs, 5.0,
+		"expected ≤5 allocs/op (Bitmap header + 2 entries slices + bucketBufs + bucketStates); got %.2f", allocs)
+}

--- a/container.go
+++ b/container.go
@@ -47,6 +47,16 @@ const (
 	// it would be divided by 16.
 	// 4 for header and 4096 for storing bitmap container. In Uint16.
 	maxContainerSize = 4 + (1<<16)/16
+
+	// bitmapDataWords is the number of uint16 words in a bitmap container's
+	// data area (= maxContainerSize minus the 4-word header). 4096 in
+	// current layout. Left as an untyped int constant so callers can use it
+	// in any numeric context (array sizes, uint16 arithmetic, int loops).
+	bitmapDataWords = maxContainerSize - 4
+
+	// bitmapDataUint64s is bitmapDataWords reinterpreted as uint64 words
+	// (used in `uint16To64SliceUnsafe`-style cast loops). 1024 in current layout.
+	bitmapDataUint64s = bitmapDataWords / 4
 )
 
 func incrCardinality(data []uint16) {
@@ -59,7 +69,11 @@ func incrCardinality(data []uint16) {
 }
 
 var invalidCardinality int = math.MaxUint16 + 10
-var maxCardinality int = math.MaxUint16 + 1
+
+// maxCardinality is the number of bit positions a bitmap container can hold
+// — equivalently, the cardinality of the value space within one container.
+// 65536 = math.MaxUint16 + 1 = bitmapDataWords * 16.
+const maxCardinality = math.MaxUint16 + 1
 
 func getCardinality(data []uint16) int {
 	// This sum has to be done using two ints to avoid overflow.


### PR DESCRIPTION
## Motivation                                                                                             

  For each bit `v` in `vals`, callers need the greatest bit `c ≤ v` in `candidates` such that `v` and `c` agree under `mask`. Emulating this with existing operations is O(N·M) per query and allocates intermediates per bit.                                

  ## Approach                                                                                                 

  **`FloorMasked(vals, candidates, mask)`** and **`FloorMaskedToBuf(...)`** are package-level functions; neither input is mutated. They run a sorted parallel walk over both inputs, dispatched per masked group.                                                         

  For each masked group:

  - Two stack-allocated `[32768]uint32` cache halves form a 65536-slot per-low-bit lookup. Slots store `bucketIdx + 1` (sentinel-0 = unset). Split into halves to stay under Go's `MaxStackVarSize` (128 KB).                                        
  - Candidates containers are processed in `originalKey` order, writing their slot into the cache for every set low-16 value.                                                   
  - Vals containers look up the cache for each set bit's low value; on a hit, the bit is set in the per-mk bucket indexed by `slot - 1`.                                         
  - At end of group, each non-empty bucket flushes once into `res`. Each candidates entry's `originalKey` is globally unique across all groups, so flushes are fresh-key writes — no OR-merges ever fire.      
                                                                                                              
  Precondition (caller commitment): `mask & 0xFFFF == 0xFFFF`. The per-bit step is a membership test of vals' low 16 bits against the matching candidates container.                                                                                                  
                                                                                                            
  ## Key areas for review                                                                                     

  - `floorMaskedInto` — masked-group walk; per-bucket scratch allocated once per call, reused across groups.
  - `processFloorGroup` — parallel walk; tie-break (candidates first at equal `originalKey`) covers "v is its own floor when v ∈ candidates".
  - `floorUpdateCache` / `emitFloorsBucketed` — closure-free signatures (`*[floorCacheHalf]uint32` pointers, not closures) are load-bearing for stack allocation. Verify with `go build -gcflags='-m=2'`.                                                 
                                                                     
  ## Risks and mitigations                                                                                    

  - **256 KB stack frame** per call from the cache halves. Verified stack- allocated; Go's per-goroutine stack grows on demand.             
  - **Mask shapes outside the precondition are undefined.** Impl internally clears the low 16 bits and treats anything there as `0xFFFF`. Tests assert the membership-regime degenerate (`mask = all-ones → vals ∩ candidates`).                                 
  - **`bucketBufs` allocation scales linearly with the largest masked-group size** (~8 KB per bucket). Typical shapes use well under 100 KB; pathological cases with thousands of distinct candidates containers collapsing into one masked group would see proportionally larger scratch. Not a correctness concern (slot encoding is `uint32`) but worth knowing for unconstrained inputs.                                                                                                   

  ## Testing                                                                                                  

  - `TestFloorMasked` — 9 abstract cases plus 2 regressions (same-destination- key re-flush, matching candidates containers behind the cursor).
  - `TestFloorMaskedFixtures` — 13 shape-based fixtures with a non-contiguous mask, exercising the sort-by-masked-key path.                                                             
  - `TestFloorMaskedToBufAllocs` — asserts ≤5 allocs/op.                                                    
  - `BenchmarkFloorMasked` / `BenchmarkFloorMaskedToBuf` across 4 workload shapes (Realistic, Dense, Sparse, Small).  