### PR TITLE
Add ContainsCursor for repeated membership probes

### DIFF
--- a/contains_cursor.go
+++ b/contains_cursor.go
@@ -1,0 +1,131 @@
+package sroar
+
+// ContainsCursor accelerates repeated Contains on a fixed Bitmap when successive
+// probes have locality: it returns the identical result to Bitmap.Contains for any
+// x in any order, and is cheapest when probes repeat the previous container or
+// advance past it (same-container repeats skip the key search; forward moves
+// gallop from the cached position at both the container and the array-value
+// level; backward moves fall back to the plain search).
+//
+// Not safe for concurrent use; the bound Bitmap must not be mutated while the
+// cursor is live.
+type ContainsCursor struct {
+	ra      *Bitmap
+	keys    node
+	numKeys int
+	maxKey  uint64 // largest container key in ra: probes above it short-circuit
+	lastIdx int    // smallest key index whose key is >= lastKey
+	// lastKey is the previous probe's key (x & mask, so its low 16 bits are
+	// always zero). Reset seeds it with 1 — not a representable key — so a fresh
+	// cursor can never false-hit the same-key cache, and idx = 0 is a valid
+	// forward starting point for any first probe.
+	lastKey       uint64
+	lastContainer []uint16
+	arrN          int  // array cardinality (valid when lastContainer != nil && !isLastBitmap)
+	arrPos        int  // lower bound of the last probed value within the array
+	isLastBitmap  bool // lastContainer is a bitmap (not array) container
+}
+
+// NewContainsCursor returns a cursor bound to ra. A nil ra (or nil cursor) reports
+// false, matching Bitmap.Contains.
+func (ra *Bitmap) NewContainsCursor() *ContainsCursor {
+	cur := &ContainsCursor{}
+	cur.Reset(ra)
+	return cur
+}
+
+// Reset re-binds the cursor to ra and clears its cache, letting callers embed a
+// ContainsCursor by value and prime it without a heap allocation.
+func (cur *ContainsCursor) Reset(ra *Bitmap) {
+	*cur = ContainsCursor{ra: ra, lastKey: 1}
+	if ra != nil {
+		cur.keys = ra.keys
+		cur.numKeys = cur.keys.numKeys()
+		if cur.numKeys > 0 {
+			cur.maxKey = cur.keys.key(cur.numKeys - 1)
+		}
+	}
+}
+
+// Contains reports whether x is set, for any x in any order (cheapest when x
+// repeats the previous container or advances past it).
+func (cur *ContainsCursor) Contains(x uint64) bool {
+	if cur == nil || cur.ra == nil {
+		return false
+	}
+	key := x & mask
+	y := uint16(x)
+	if key == cur.lastKey {
+		if cur.lastContainer == nil {
+			return false
+		}
+		if cur.isLastBitmap {
+			return bitmap(cur.lastContainer).has(y)
+		}
+		return cur.arrayHas(y)
+	}
+	if key > cur.maxKey {
+		// beyond the last container: absent, and no cursor state to update —
+		// turns backward probes above the range from a full search into one
+		// compare (placed after the same-key path to keep cache hits untouched).
+		return false
+	}
+	var idx int
+	if key > cur.lastKey {
+		idx = cur.lastIdx // forward: gallop from where we are
+		if idx < cur.numKeys && cur.keys.key(idx) < key {
+			idx = cur.keys.searchFrom(idx, key)
+		}
+	} else {
+		idx = cur.keys.search(key) // backward: plain search
+	}
+	cur.lastIdx = idx
+	cur.lastKey = key
+	if idx >= cur.numKeys || cur.keys.key(idx) != key {
+		cur.lastContainer = nil
+		return false
+	}
+	cur.lastContainer = cur.ra.getContainer(cur.keys.val(idx))
+	switch cur.lastContainer[indexType] {
+	case typeBitmap:
+		cur.isLastBitmap = true
+		return bitmap(cur.lastContainer).has(y)
+	case typeArray:
+		cur.isLastBitmap = false
+		cur.arrN = getCardinality(cur.lastContainer)
+		cur.arrPos = cur.arrN // arrayHas re-establishes the lower bound
+		return cur.arrayHas(y)
+	default:
+		// mirror Contains' default-false on unknown container types; nil cont
+		// makes repeat probes into this container report false as well.
+		cur.lastContainer = nil
+		return false
+	}
+}
+
+// arrayHas answers has(y) for the cached array container. arrPos holds the
+// lower bound of the previous probe (the index of the smallest value >= it,
+// arrN when past the end), so everything left of arrPos is smaller than any
+// forward probe.
+func (cur *ContainsCursor) arrayHas(y uint16) bool {
+	c, si, i := cur.lastContainer, int(startIdx), cur.arrPos
+	switch {
+	case i < cur.arrN && c[si+i] == y:
+		// the cursor already sits on y
+		return true
+	case i < cur.arrN && c[si+i] < y:
+		// forward: advance from the cursor, O(log(distance moved))
+		i = advanceUntil(c[si:], i, cur.arrN, y)
+	case i == 0 || c[si+i-1] < y:
+		// y falls in the gap right below the cursor — before the first value
+		// (i == 0), between the neighbours (c[i-1] < y < c[i]), or past the
+		// last value (i == arrN and c[arrN-1] < y): provably absent, and
+		// arrPos is already y's lower bound. One compare, no search.
+		return false
+	default:
+		// true backward move: full binary search
+		i = array(c).find(y)
+	}
+	cur.arrPos = i
+	return i < cur.arrN && c[si+i] == y
+}

--- a/contains_cursor_test.go
+++ b/contains_cursor_test.go
@@ -1,0 +1,259 @@
+package sroar
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+)
+
+// The fixtures are deterministic (fixed seeds), expensive to build (millions of
+// inserts), and only ever probed — so they are constructed at most once per test
+// binary and shared read-only across tests and benchmarks.
+var (
+	denseOnce   sync.Once
+	denseShared *Bitmap
+	mixedOnce   sync.Once
+	mixedShared *Bitmap
+)
+
+// denseBitmap spreads 2M values over a 200M range: ~3050 array containers of
+// ~650 values each. Exercises the array-container paths.
+func denseBitmap() *Bitmap {
+	denseOnce.Do(func() {
+		b := NewBitmap()
+		rng := rand.New(rand.NewSource(7))
+		max := int64(200_000_000)
+		for i := 0; i < 2_000_000; i++ {
+			b.Set(uint64(rng.Int63n(max)))
+		}
+		denseShared = b
+	})
+	return denseShared
+}
+
+// mixedBitmap combines fully-populated bitmap containers, mid-density array
+// containers, empty key ranges, and a sparse tail — so probes cross every
+// container type and every miss shape.
+func mixedBitmap() *Bitmap {
+	mixedOnce.Do(func() {
+		mixedShared = buildMixedBitmap()
+	})
+	return mixedShared
+}
+
+func buildMixedBitmap() *Bitmap {
+	b := NewBitmap()
+	// bitmap containers: every value in [0, 4<<16)
+	for x := uint64(0); x < 4<<16; x++ {
+		b.Set(x)
+	}
+	// gap: no containers for keys in [4<<16, 8<<16)
+	// array containers: ~700/container over [8<<16, 12<<16)
+	rng := rand.New(rand.NewSource(21))
+	for i := 0; i < 2800; i++ {
+		b.Set(uint64(8<<16) + uint64(rng.Int63n(4<<16)))
+	}
+	// dense-but-not-full bitmap containers: every even value in [16<<16, 18<<16)
+	for x := uint64(16 << 16); x < 18<<16; x += 2 {
+		b.Set(x)
+	}
+	// sparse tail: single-value containers far out
+	for i := uint64(0); i < 20; i++ {
+		b.Set(uint64(32<<16) + i*3*65536)
+	}
+	return b
+}
+
+// The cursor must match Bitmap.Contains for any access order, on both array and
+// bitmap containers, hits and misses, present and absent keys.
+func TestContainsCursorEquivalence(t *testing.T) {
+	fixtures := []struct {
+		name string
+		bm   *Bitmap
+		max  uint64
+	}{
+		{"dense_arrays", denseBitmap(), 200_000_000},
+		{"mixed_containers", mixedBitmap(), 90 << 16},
+	}
+	for _, fx := range fixtures {
+		t.Run(fx.name, func(t *testing.T) {
+			rng := rand.New(rand.NewSource(99))
+			cur := fx.bm.NewContainsCursor()
+			for i := 0; i < 2_000_000; i++ { // random: forward gallops + backward fallbacks
+				x := uint64(rng.Int63n(int64(fx.max)))
+				if cur.Contains(x) != fx.bm.Contains(x) {
+					t.Fatalf("random mismatch at %d", x)
+				}
+			}
+			cur2 := fx.bm.NewContainsCursor()
+			for x := uint64(0); x < fx.max; x += uint64(rng.Intn(97) + 1) { // monotonic
+				if cur2.Contains(x) != fx.bm.Contains(x) {
+					t.Fatalf("monotonic mismatch at %d", x)
+				}
+			}
+		})
+	}
+}
+
+func TestContainsCursorEdgeCases(t *testing.T) {
+	t.Run("nil_cursor_and_nil_bitmap", func(t *testing.T) {
+		var nilCur *ContainsCursor
+		if nilCur.Contains(42) {
+			t.Fatal("nil cursor must report false")
+		}
+		var nilBm *Bitmap
+		if nilBm.NewContainsCursor().Contains(42) {
+			t.Fatal("cursor over nil bitmap must report false")
+		}
+	})
+	t.Run("zero_value_cursor", func(t *testing.T) {
+		var cur ContainsCursor // embedded-by-value, never Reset
+		if cur.Contains(0) || cur.Contains(42) {
+			t.Fatal("zero-value cursor must report false")
+		}
+	})
+	t.Run("empty_bitmap", func(t *testing.T) {
+		cur := NewBitmap().NewContainsCursor()
+		for _, x := range []uint64{0, 1, 65535, 65536, 1 << 40} {
+			if cur.Contains(x) {
+				t.Fatalf("empty bitmap: %d must be false", x)
+			}
+		}
+	})
+	t.Run("single_container", func(t *testing.T) {
+		b := NewBitmap()
+		b.Set(100)
+		b.Set(200)
+		cur := b.NewContainsCursor()
+		checks := []struct {
+			x    uint64
+			want bool
+		}{{0, false}, {100, true}, {150, false}, {200, true}, {65535, false}, {1 << 30, false}}
+		for _, c := range checks {
+			if got := cur.Contains(c.x); got != c.want {
+				t.Fatalf("Contains(%d)=%v want %v", c.x, got, c.want)
+			}
+		}
+	})
+	t.Run("beyond_max_then_backward", func(t *testing.T) {
+		b := denseBitmap()
+		cur := b.NewContainsCursor()
+		if cur.Contains(1 << 50) { // far past the last container
+			t.Fatal("beyond-max must be false")
+		}
+		// backward probes after exhausting the key space must still be exact
+		rng := rand.New(rand.NewSource(5))
+		for i := 0; i < 100_000; i++ {
+			x := uint64(rng.Int63n(200_000_000))
+			if cur.Contains(x) != b.Contains(x) {
+				t.Fatalf("backward-after-end mismatch at %d", x)
+			}
+		}
+	})
+	t.Run("reset_rebind", func(t *testing.T) {
+		a, b := denseBitmap(), mixedBitmap()
+		var cur ContainsCursor
+		cur.Reset(a)
+		rng := rand.New(rand.NewSource(11))
+		for i := 0; i < 100_000; i++ {
+			x := uint64(rng.Int63n(200_000_000))
+			if cur.Contains(x) != a.Contains(x) {
+				t.Fatalf("bound to a: mismatch at %d", x)
+			}
+		}
+		cur.Reset(b) // rebind mid-life: no state may leak
+		for i := 0; i < 100_000; i++ {
+			x := uint64(rng.Int63n(90 << 16))
+			if cur.Contains(x) != b.Contains(x) {
+				t.Fatalf("rebound to b: mismatch at %d", x)
+			}
+		}
+		cur.Reset(nil)
+		if cur.Contains(1) {
+			t.Fatal("rebound to nil: must report false")
+		}
+	})
+}
+
+// Contains vs ContainsCursor across three probe patterns: small forward gaps
+// (probes mostly repeat a container), large forward gaps (every probe a new
+// container, where the forward gallop beats the from-scratch search), and fully
+// random (no locality — the cursor's worst case).
+func BenchmarkContainsCursor(b *testing.B) {
+	bm := denseBitmap()
+	max := uint64(200_000_000)
+
+	ascProbes := func(avgStep int) []uint64 {
+		rng := rand.New(rand.NewSource(7))
+		var probes []uint64
+		for x := uint64(0); x < max; x += uint64(rng.Intn(avgStep) + 1) {
+			probes = append(probes, x)
+		}
+		return probes
+	}
+	runAsc := func(b *testing.B, probes []uint64, useCursor bool) {
+		b.ReportAllocs()
+		// increment-and-wrap rather than i%n: a hardware integer division in the
+		// timed loop would compress the measured Contains-vs-Cursor ratio.
+		n := len(probes)
+		var s int
+		j := -1
+		cur := bm.NewContainsCursor()
+		for i := 0; i < b.N; i++ {
+			j++
+			if j == n {
+				j = 0
+				cur.Reset(bm) // wrapped: keep probes non-decreasing within a pass
+			}
+			hit := false
+			if useCursor {
+				hit = cur.Contains(probes[j])
+			} else {
+				hit = bm.Contains(probes[j])
+			}
+			if hit {
+				s++
+			}
+		}
+		sink = s
+	}
+
+	for _, rg := range []struct {
+		name    string
+		avgStep int
+	}{{"smallgap", 50}, {"biggap", 400_000}} {
+		probes := ascProbes(rg.avgStep)
+		b.Run(rg.name+"/Contains", func(b *testing.B) { runAsc(b, probes, false) })
+		b.Run(rg.name+"/Cursor", func(b *testing.B) { runAsc(b, probes, true) })
+	}
+
+	rng := rand.New(rand.NewSource(11))
+	randp := make([]uint64, 1<<20)
+	for i := range randp {
+		randp[i] = uint64(rng.Int63n(int64(max)))
+	}
+	m := len(randp)
+	b.Run("random/Contains", func(b *testing.B) {
+		b.ReportAllocs()
+		var s int
+		for i := 0; i < b.N; i++ {
+			if bm.Contains(randp[i%m]) {
+				s++
+			}
+		}
+		sink = s
+	})
+	b.Run("random/Cursor", func(b *testing.B) {
+		b.ReportAllocs()
+		cur := bm.NewContainsCursor()
+		var s int
+		for i := 0; i < b.N; i++ {
+			if cur.Contains(randp[i%m]) {
+				s++
+			}
+		}
+		sink = s
+	})
+}
+
+var sink int


### PR DESCRIPTION
Adds `ContainsCursor`, a stateful accelerator for repeated `Contains` on a **fixed** bitmap when successive probes have locality (especially forward runs).

## What

`Bitmap.Contains` runs a binary search over the container keys on every call, and *array* containers run a second binary search over their sorted values. A caller that probes the same bitmap repeatedly — a value that repeats a container or advances through the set (an ascending id scan) — pays both searches every time.

`ContainsCursor` caches state at **two levels**:
- **Container**: the last resolved container is cached, so a probe into the same 2^16 block skips the key search; a forward key gallops from the cached index via the existing `node.searchFrom` (O(log gap)); a backward key or the first probe falls back to the plain from-scratch search.
- **Within an array container**: a cached lower-bound position answers ascending probes without searching — a miss landing inside the current gap is decided by a **single predecessor compare**, a forward hit advances via the shared `advanceUntil` kernel (O(log distance), distance-1 fast path), and only a true backward move pays a full binary search. Bitmap containers already answer `has()` in O(1) and use the plain bit test.

API:
- `(*Bitmap).NewContainsCursor()`
- `(*ContainsCursor).Reset(ra)` — re-bind in place, so callers can embed the cursor **by value** and avoid a per-use heap allocation.

## Correctness

The result is **identical to `Bitmap.Contains` for any `x` in any order** — locality only affects speed. A backward probe rewinds/re-searches at both levels; nil-safe; unknown container types mirror `Contains`' default-false. Tests cover:
- equivalence vs `Bitmap.Contains` over two fixtures — array-only containers and a **mixed fixture with bitmap containers, gaps, and sparse tails** — under 2M random probes (forward gallops + backward fallbacks at both levels) plus monotonic sweeps;
- edge cases: nil cursor/bitmap, zero-value (embedded) cursor, empty bitmap, single container, probes beyond the max element then backward, and `Reset` rebinding to a different/nil bitmap.

The existing suite is unchanged and green; cursor tests pass under `-race`.

## Benchmarks

Dense bitmap (2M sets over a 200M range → array containers), `Contains` vs `ContainsCursor`, 0 allocs/op in all regimes:

```
                                       Contains   Cursor
small forward gaps (repeat a container)  29.6 ns    5.1 ns   (5.8x)
large forward gaps (new container each)  30.2 ns   21.9 ns   (1.38x)
fully random (no locality)              110.0 ns  112.4 ns   (parity)
```

## Motivation (downstream: Weaviate BM25)

Weaviate's BlockMax-WAND keyword search probes a per-segment tombstone bitmap at each term's monotonically-advancing docID (`SegmentBlockMax.tombstoned`); on update-heavy segments that path was ~40-50% of scoring CPU. Wiring in a value-embedded `ContainsCursor` (primed via `Reset`, **zero extra allocations**), bit-identical top-K on a real update-heavy corpus:

```
                 plain Contains   ContainsCursor
common_200 query     144 ms          79 ms    (1.82x)
random_200 query      19 ms          11 ms    (1.79x)
```

The win holds 1.7–1.95x across query shape / size / limit and OR/AND operators, and the same cursor applied to the filter (`WHERE`) bitmap recovers filtered-query performance as well. Profiling after the change shows the tombstone lookup dropped to ~12% and is memory-bound — at the floor for this access pattern.

The weaviate wiring will be a follow-up PR once this is tagged. Additive and non-breaking: no existing API changes.


