### PR TITLE
ContainsCursor: name each arrayHas case and document the invariant by example

### DIFF
--- a/contains_cursor.go
+++ b/contains_cursor.go
@@ -103,10 +103,24 @@ func (cur *ContainsCursor) Contains(x uint64) bool {
 	}
 }
 
-// arrayHas answers has(y) for the cached array container. arrPos holds the
-// lower bound of the previous probe (the index of the smallest value >= it,
-// arrN when past the end), so everything left of arrPos is smaller than any
-// forward probe.
+// arrayHas answers has(y) for the cached array container.
+//
+// Invariant: arrPos is the lower bound of the previous probe — the index of the
+// smallest value >= it, arrN when the probe was past the last value. Example
+// with values c = [10 20 30 40] after a previous probe of 25 (arrPos = 2,
+// c[2] = 30):
+//
+//	y = 30          hit under the cursor          -> true, no search
+//	y = 31..39      forward of the cursor         -> advanceUntil from index 2
+//	y = 21..29      inside the gap (20, 30)       -> absent, one compare (20 < y)
+//	y <= 20         at or behind the previous gap -> full binary search
+//
+// Only the last shape searches: the invariant already brackets y in the other
+// three. The single-gap check cannot be extended to earlier gaps
+// (c[i-2]..c[i-1] and so on) — locating which earlier gap holds y IS the
+// binary search that find() performs. Nor are explicit y < c[0] / y > c[N-1]
+// boundary cases needed: both are answered below via the cursor's neighbours
+// (already in cache) instead of re-reading the array edges.
 func (cur *ContainsCursor) arrayHas(y uint16) bool {
 	c, si, i := cur.lastContainer, int(startIdx), cur.arrPos
 	switch {
@@ -114,16 +128,19 @@ func (cur *ContainsCursor) arrayHas(y uint16) bool {
 		// the cursor already sits on y
 		return true
 	case i < cur.arrN && c[si+i] < y:
-		// forward: advance from the cursor, O(log(distance moved))
+		// forward of the cursor: advance, O(log(distance moved))
 		i = advanceUntil(c[si:], i, cur.arrN, y)
-	case i == 0 || c[si+i-1] < y:
-		// y falls in the gap right below the cursor — before the first value
-		// (i == 0), between the neighbours (c[i-1] < y < c[i]), or past the
-		// last value (i == arrN and c[arrN-1] < y): provably absent, and
-		// arrPos is already y's lower bound. One compare, no search.
+	case i == 0:
+		// cursor at the start and c[0] > y (or the container is empty):
+		// y precedes every value
+		return false
+	case c[si+i-1] < y:
+		// inside the gap right below the cursor (c[i-1] < y < c[i], or past
+		// the last value when i == arrN): provably absent, and arrPos is
+		// already y's lower bound
 		return false
 	default:
-		// true backward move: full binary search
+		// at or behind the previous gap: full binary search
 		i = array(c).find(y)
 	}
 	cur.arrPos = i


### PR DESCRIPTION
Follow-up to the #44 review discussion on `arrayHas` readability.

## What

No behavioral change. The switch now has one case per probe shape, and the doc carries a worked example:

```
Invariant: arrPos is the lower bound of the previous probe. Example with
values c = [10 20 30 40] after a previous probe of 25 (arrPos = 2, c[2] = 30):

  y = 30          hit under the cursor          -> true, no search
  y = 31..39      forward of the cursor         -> advanceUntil from index 2
  y = 21..29      inside the gap (20, 30)       -> absent, one compare (20 < y)
  y <= 20         at or behind the previous gap -> full binary search
```

## Why not the boundary-case formulation

The suggested `y < c[0]` / `y > c[N-1]` / `y == c[i]` / `y > c[i]` / `find` shape was considered and deliberately not used:

- **`y < c[0]` and `y > c[N-1]` are already answered** by the cursor cases without touching the array edges: `i == 0` with `c[i] > y` *is* "y precedes everything", and `i == arrN` with `c[i-1] < y` *is* "y beyond the last value". Reading `c[N-1]` explicitly would add a potentially cold cache-line access to every probe (the whole point of the cursor is staying on the warm neighbourhood).
- **Dropping the in-gap case would forfeit the main win**: for ascending probes with step below the container's mean value gap, ~half of all probes are misses landing in the gap right below the cursor. Sending those to `find` is what the original code did — restoring it would take smallgap from ~5.3 back to ~15+ ns/op.
- **The gap check cannot "go on and on" (`c[i-2] < y < c[i-1]`, …)**: the single gap below the cursor is special because the invariant brackets it with one compare that's already in cache. Locating which *earlier* gap holds y is precisely the binary search — those cases are, collectively, the `default: find` branch.

## Verification

Equivalence + edge tests + `-race` + full suite green; benchmarks unchanged (smallgap 5.28 ns/op, biggap 21.8, random parity).