### PR TITLE
Add ContainsCursor.NextGeq: successor queries from cursor state

### DIFF
--- a/container.go
+++ b/container.go
@@ -788,3 +788,24 @@ func containerAndNot(ac, bc, buf []uint16) []uint16 {
 	}
 	panic("containerAndNot: We should not reach here")
 }
+
+// nextGeq returns the smallest set value >= y in bitmap container b, and
+// whether one exists.
+func (b bitmap) nextGeq(y uint16) (uint16, bool) {
+	data := b[startIdx:]
+	w := int(y >> 4)
+	// bitmapMask[pos] is 1<<(15-pos), so positions >= y&15 occupy the low bits
+	// of the word: keep them, drop the earlier (higher) bits.
+	word := data[w] & (0xFFFF >> (y & 0xF))
+	for {
+		if word != 0 {
+			pos := uint16(bits.LeadingZeros16(word))
+			return uint16(w)<<4 | pos, true
+		}
+		w++
+		if w >= len(data) {
+			return 0, false
+		}
+		word = data[w]
+	}
+}

--- a/contains_cursor.go
+++ b/contains_cursor.go
@@ -62,7 +62,9 @@ func (cur *ContainsCursor) Contains(x uint64) bool {
 		if cur.isLastBitmap {
 			return bitmap(cur.lastContainer).has(y)
 		}
-		return cur.arrayHas(y)
+		i := cur.arrayGeqPos(y)
+		cur.arrPos = i
+		return i < cur.arrN && cur.lastContainer[int(startIdx)+i] == y
 	}
 	if key > cur.maxKey {
 		// beyond the last container: absent, and no cursor state to update —
@@ -93,8 +95,10 @@ func (cur *ContainsCursor) Contains(x uint64) bool {
 	case typeArray:
 		cur.isLastBitmap = false
 		cur.arrN = getCardinality(cur.lastContainer)
-		cur.arrPos = cur.arrN // arrayHas re-establishes the lower bound
-		return cur.arrayHas(y)
+		cur.arrPos = cur.arrN // forces arrayGeqPos to search from scratch
+		i := cur.arrayGeqPos(y)
+		cur.arrPos = i
+		return i < cur.arrN && cur.lastContainer[int(startIdx)+i] == y
 	default:
 		// mirror Contains' default-false on unknown container types; nil cont
 		// makes repeat probes into this container report false as well.
@@ -103,31 +107,24 @@ func (cur *ContainsCursor) Contains(x uint64) bool {
 	}
 }
 
-// arrayHas answers has(y) for the cached array container. arrPos holds the
-// lower bound of the previous probe (the index of the smallest value >= it,
-// arrN when past the end), so everything left of arrPos is smaller than any
-// forward probe.
-func (cur *ContainsCursor) arrayHas(y uint16) bool {
+// arrayGeqPos returns the index of the smallest value >= y in the cached array
+// container (arrN if none). arrPos holds the lower bound of the previous probe,
+// so everything left of it is smaller than any forward probe: a y at the cursor
+// or in the gap just below it resolves in O(1), a forward move advances in
+// O(log(distance moved)), a true backward move binary-searches from scratch.
+func (cur *ContainsCursor) arrayGeqPos(y uint16) int {
 	c, si, i := cur.lastContainer, int(startIdx), cur.arrPos
 	switch {
-	case i < cur.arrN && c[si+i] == y:
-		// the cursor already sits on y
-		return true
 	case i < cur.arrN && c[si+i] < y:
-		// forward: advance from the cursor, O(log(distance moved))
-		i = advanceUntil(c[si:], i, cur.arrN, y)
+		return advanceUntil(c[si:], i, cur.arrN, y)
 	case i == 0 || c[si+i-1] < y:
-		// y falls in the gap right below the cursor — before the first value
-		// (i == 0), between the neighbours (c[i-1] < y < c[i]), or past the
-		// last value (i == arrN and c[arrN-1] < y): provably absent, and
-		// arrPos is already y's lower bound. One compare, no search.
-		return false
+		// before the first value (i == 0), between the neighbours
+		// (c[i-1] < y <= c[i]), or past the last value (i == arrN and
+		// c[arrN-1] < y): i is already y's lower bound
+		return i
 	default:
-		// true backward move: full binary search
-		i = array(c).find(y)
+		return array(c).find(y)
 	}
-	cur.arrPos = i
-	return i < cur.arrN && c[si+i] == y
 }
 
 // NextGeq returns the smallest set value >= x and whether one exists. It shares
@@ -141,14 +138,29 @@ func (cur *ContainsCursor) NextGeq(x uint64) (uint64, bool) {
 		return 0, false
 	}
 	key := x & mask
-	if key > cur.maxKey {
-		return 0, false
-	}
 	y := uint16(x)
 	var idx int
 	switch {
 	case key == cur.lastKey:
-		idx = cur.lastIdx
+		// same-key fast path: resolve within the cached container without
+		// touching the keys node or the arena. Skipping the maxKey check is
+		// sound — lastKey is a resolved key (<= maxKey) or the unmatchable
+		// sentinel.
+		if cur.lastContainer == nil {
+			idx = cur.lastIdx // key resolved as absent: walk from its slot
+			break
+		}
+		if cur.isLastBitmap {
+			if v, ok := bitmap(cur.lastContainer).nextGeq(y); ok {
+				return key | uint64(v), true
+			}
+		} else if pos := cur.arrayGeqPos(y); pos < cur.arrN {
+			cur.arrPos = pos
+			return key | uint64(cur.lastContainer[int(startIdx)+pos]), true
+		}
+		idx = cur.lastIdx + 1 // cached container exhausted: successor is a later container's min
+	case key > cur.maxKey:
+		return 0, false
 	case key > cur.lastKey:
 		idx = cur.lastIdx // forward: gallop from where we are
 		if idx < cur.numKeys && cur.keys.key(idx) < key {
@@ -191,7 +203,6 @@ func (cur *ContainsCursor) NextGeq(x uint64) (uint64, bool) {
 		}
 		// unknown container types are skipped, mirroring Contains' default-false
 	}
-	// no successor (only possible via empty or unknown trailing containers);
-	// cursor state is left untouched
+	// no set value at or after x; cursor state is left untouched
 	return 0, false
 }

--- a/contains_cursor.go
+++ b/contains_cursor.go
@@ -62,9 +62,7 @@ func (cur *ContainsCursor) Contains(x uint64) bool {
 		if cur.isLastBitmap {
 			return bitmap(cur.lastContainer).has(y)
 		}
-		i := cur.arrayGeqPos(y)
-		cur.arrPos = i
-		return i < cur.arrN && cur.lastContainer[int(startIdx)+i] == y
+		return cur.arrayHas(y)
 	}
 	if key > cur.maxKey {
 		// beyond the last container: absent, and no cursor state to update —
@@ -95,10 +93,8 @@ func (cur *ContainsCursor) Contains(x uint64) bool {
 	case typeArray:
 		cur.isLastBitmap = false
 		cur.arrN = getCardinality(cur.lastContainer)
-		cur.arrPos = cur.arrN // forces arrayGeqPos to search from scratch
-		i := cur.arrayGeqPos(y)
-		cur.arrPos = i
-		return i < cur.arrN && cur.lastContainer[int(startIdx)+i] == y
+		cur.arrPos = cur.arrN // arrayHas re-establishes the lower bound
+		return cur.arrayHas(y)
 	default:
 		// mirror Contains' default-false on unknown container types; nil cont
 		// makes repeat probes into this container report false as well.
@@ -107,43 +103,45 @@ func (cur *ContainsCursor) Contains(x uint64) bool {
 	}
 }
 
-// arrayGeqPos returns the index of the smallest value >= y in the cached array
-// container (arrN if none); callers derive membership by comparing c[result]
-// against y and maintain the invariant by storing the result back into arrPos.
+// arrayHas answers has(y) for the cached array container, and leaves arrPos at
+// y's lower bound — the index of the smallest value >= y, arrN when past the
+// end. NextGeq reads that invariant to turn the same probe into a successor.
+// The hit and in-gap cases hold it without a store: arrPos is already the
+// lower bound there. Example with values c = [10 20 30 40] after a previous
+// probe of 25 (arrPos = 2, c[2] = 30):
 //
-// Invariant: arrPos is the lower bound of the previous probe — the index of the
-// smallest value >= it, arrN when the probe was past the last value. Example
-// with values c = [10 20 30 40] after a previous probe of 25 (arrPos = 2,
-// c[2] = 30):
-//
-//	y = 31..39      forward of the cursor         -> advanceUntil from index 2
-//	y = 21..30      at the cursor or in its gap   -> index 2, one compare (20 < y)
-//	y <= 20         at or behind the previous gap -> full binary search
+//	y = 30          at the cursor              -> one compare, no store
+//	y = 31..39      forward of the cursor      -> advanceUntil from index 2
+//	y = 21..29      in the gap below           -> one compare (20 < y), no store
+//	y <= 20         at or behind the gap       -> full binary search
 //
 // Only the last shape searches: the invariant already brackets y in the other
-// two. The single-gap check cannot be extended to earlier gaps
+// three. The single-gap check cannot be extended to earlier gaps
 // (c[i-2]..c[i-1] and so on) — locating which earlier gap holds y IS the
 // binary search that find() performs. Nor are explicit y < c[0] / y > c[N-1]
 // boundary cases needed: both are answered below via the cursor's neighbours
 // (already in cache) instead of re-reading the array edges.
-func (cur *ContainsCursor) arrayGeqPos(y uint16) int {
+func (cur *ContainsCursor) arrayHas(y uint16) bool {
 	c, si, i := cur.lastContainer, int(startIdx), cur.arrPos
 	switch {
+	case i < cur.arrN && c[si+i] == y:
+		// the cursor already sits on y
+		return true
 	case i < cur.arrN && c[si+i] < y:
-		// forward of the cursor: advance, O(log(distance moved))
-		return advanceUntil(c[si:], i, cur.arrN, y)
-	case i == 0:
-		// cursor at the start and c[0] >= y (or the container is empty):
-		// 0 is y's lower bound
-		return 0
-	case c[si+i-1] < y:
-		// at the cursor or inside the gap right below it (c[i-1] < y <= c[i],
-		// or past the last value when i == arrN): i is already y's lower bound
-		return i
+		// forward: advance from the cursor, O(log(distance moved))
+		i = advanceUntil(c[si:], i, cur.arrN, y)
+	case i == 0 || c[si+i-1] < y:
+		// y falls in the gap right below the cursor — before the first value
+		// (i == 0), between the neighbours (c[i-1] < y < c[i]), or past the
+		// last value (i == arrN and c[arrN-1] < y): provably absent, and
+		// arrPos is already y's lower bound. One compare, no search.
+		return false
 	default:
-		// at or behind the previous gap: full binary search
-		return array(c).find(y)
+		// true backward move: full binary search
+		i = array(c).find(y)
 	}
+	cur.arrPos = i
+	return i < cur.arrN && c[si+i] == y
 }
 
 // NextGeq returns the smallest set value >= x and whether one exists. It shares
@@ -173,9 +171,11 @@ func (cur *ContainsCursor) NextGeq(x uint64) (uint64, bool) {
 			if v, ok := bitmap(cur.lastContainer).nextGeq(y); ok {
 				return key | uint64(v), true
 			}
-		} else if pos := cur.arrayGeqPos(y); pos < cur.arrN {
-			cur.arrPos = pos
-			return key | uint64(cur.lastContainer[int(startIdx)+pos]), true
+		} else if cur.arrayHas(y) {
+			return key | uint64(y), true
+		} else if cur.arrPos < cur.arrN {
+			// miss, but arrayHas left arrPos at y's lower bound: the successor
+			return key | uint64(cur.lastContainer[int(startIdx)+cur.arrPos]), true
 		}
 		idx = cur.lastIdx + 1 // cached container exhausted: successor is a later container's min
 	case key > cur.maxKey:

--- a/contains_cursor.go
+++ b/contains_cursor.go
@@ -129,3 +129,69 @@ func (cur *ContainsCursor) arrayHas(y uint16) bool {
 	cur.arrPos = i
 	return i < cur.arrN && c[si+i] == y
 }
+
+// NextGeq returns the smallest set value >= x and whether one exists. It shares
+// the cursor's cache and leaves the cursor positioned on the returned value, so
+// interleaving Contains and NextGeq with non-decreasing arguments keeps both on
+// their fast paths. This is the successor primitive for leapfrog intersection:
+// instead of probing candidates one by one, a caller can jump directly to the
+// bitmap's next admissible value.
+func (cur *ContainsCursor) NextGeq(x uint64) (uint64, bool) {
+	if cur == nil || cur.ra == nil {
+		return 0, false
+	}
+	key := x & mask
+	if key > cur.maxKey {
+		return 0, false
+	}
+	y := uint16(x)
+	var idx int
+	switch {
+	case key == cur.lastKey:
+		idx = cur.lastIdx
+	case key > cur.lastKey:
+		idx = cur.lastIdx // forward: gallop from where we are
+		if idx < cur.numKeys && cur.keys.key(idx) < key {
+			idx = cur.keys.searchFrom(idx, key)
+		}
+	default:
+		idx = cur.keys.search(key) // backward: plain search
+	}
+	// walk containers forward until one holds a value at or after x; for
+	// containers past x's own, any set value qualifies (want == 0)
+	for ; idx < cur.numKeys; idx++ {
+		ck := cur.keys.key(idx)
+		c := cur.ra.getContainer(cur.keys.val(idx))
+		n := getCardinality(c)
+		if n == 0 {
+			continue
+		}
+		want := uint16(0)
+		if ck == key {
+			want = y
+		}
+		switch c[indexType] {
+		case typeBitmap:
+			if v, ok := bitmap(c).nextGeq(want); ok {
+				cur.lastIdx, cur.lastKey = idx, ck
+				cur.lastContainer, cur.isLastBitmap = c, true
+				return ck | uint64(v), true
+			}
+		case typeArray:
+			pos := 0
+			if want > 0 {
+				pos = array(c).find(want)
+			}
+			if pos < n {
+				cur.lastIdx, cur.lastKey = idx, ck
+				cur.lastContainer, cur.isLastBitmap = c, false
+				cur.arrN, cur.arrPos = n, pos
+				return ck | uint64(c[int(startIdx)+pos]), true
+			}
+		}
+		// unknown container types are skipped, mirroring Contains' default-false
+	}
+	// no successor (only possible via empty or unknown trailing containers);
+	// cursor state is left untouched
+	return 0, false
+}

--- a/contains_cursor_nextgeq_test.go
+++ b/contains_cursor_nextgeq_test.go
@@ -158,10 +158,46 @@ func TestNextGeqEdgeCases(t *testing.T) {
 			}
 		}
 	})
+	// A same-key probe past the cached container's last value must fall through
+	// to the "cached container exhausted" branch (idx = lastIdx+1) and let a
+	// LATER container supply the successor. The random differential reaches the
+	// array shape of this often but never the bitmap shape, so assert both.
+	t.Run("bitmap_exhausted_then_later_container", func(t *testing.T) {
+		b := NewBitmap()
+		for x := uint64(0); x < 65536; x += 2 {
+			b.Set(x) // 32768 values -> key-0 bitmap container; last set bit 65534
+		}
+		b.Set(2<<16 + 7)
+		cur := b.NewContainsCursor()
+		if v, ok := cur.NextGeq(100); !ok || v != 100 { // land in the key-0 bitmap
+			t.Fatalf("NextGeq(100) = (%d,%v), want (100,true)", v, ok)
+		}
+		// same key 0, past the last set bit: bitmap.nextGeq fails, so the walk
+		// must advance to the key-2 container's minimum.
+		if v, ok := cur.NextGeq(65535); !ok || v != 2<<16+7 {
+			t.Fatalf("NextGeq(65535) = (%d,%v), want (%d,true)", v, ok, 2<<16+7)
+		}
+	})
+	t.Run("array_exhausted_then_later_container", func(t *testing.T) {
+		b := NewBitmap()
+		b.Set(10)
+		b.Set(20) // key-0 array container
+		b.Set(2<<16 + 7)
+		cur := b.NewContainsCursor()
+		if v, ok := cur.NextGeq(10); !ok || v != 10 { // land in the key-0 array
+			t.Fatalf("NextGeq(10) = (%d,%v), want (10,true)", v, ok)
+		}
+		if v, ok := cur.NextGeq(21); !ok || v != 2<<16+7 { // past the array's max
+			t.Fatalf("NextGeq(21) = (%d,%v), want (%d,true)", v, ok, 2<<16+7)
+		}
+	})
 }
 
-// Leapfrog successor scan: the sparse-filter iteration pattern NextGeq exists
-// for (jump, land, jump), vs re-probing candidates one by one with Contains.
+// Ascending small-gap jumps over denseBitmap (all array containers): jumps of
+// ~1-2000 against ~650-value/container arrays keep almost every probe in the
+// same container, so this measures the array same-container fast path
+// (arrayGeqPos). It does NOT exercise bitmap.nextGeq or the cross-container
+// walk — see BenchmarkNextGeqBitmap and BenchmarkNextGeqCrossContainer for those.
 func BenchmarkNextGeqLeapfrog(b *testing.B) {
 	bm := denseBitmap()
 	max := uint64(200_000_000)
@@ -170,6 +206,97 @@ func BenchmarkNextGeqLeapfrog(b *testing.B) {
 	gaps := make([]uint64, 1<<16)
 	for i := range gaps {
 		gaps[i] = uint64(rng.Intn(2000) + 1)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	cur := bm.NewContainsCursor()
+	x := uint64(0)
+	var s int
+	for i := 0; i < b.N; i++ {
+		v, ok := cur.NextGeq(x)
+		if !ok {
+			cur.Reset(bm)
+			x = 0
+			continue
+		}
+		s++
+		x = v + gaps[i&(1<<16-1)]
+		if x >= max {
+			cur.Reset(bm)
+			x = 0
+		}
+	}
+	sink = s
+}
+
+var (
+	bitmapContainersOnce   sync.Once
+	bitmapContainersShared *Bitmap
+)
+
+// bitmapContainerFixture builds a bitmap whose every container is a bitmap
+// container (cardinality > 4096), sparse enough (every 5th value) that
+// bitmap.nextGeq scans real zero-runs. The denseBitmap/mixedBitmap array
+// containers never enter bitmap.nextGeq, so this fixture is needed to bench it.
+func bitmapContainerFixture() *Bitmap {
+	bitmapContainersOnce.Do(func() {
+		b := NewBitmap()
+		for k := uint64(0); k < 16; k++ {
+			base := k << 16
+			for v := uint64(0); v < 1<<16; v += 5 { // ~13108/key -> bitmap container
+				b.Set(base | v)
+			}
+		}
+		bitmapContainersShared = b
+	})
+	return bitmapContainersShared
+}
+
+// BenchmarkNextGeqBitmap is the bitmap-container analog of
+// BenchmarkNextGeqLeapfrog: small ascending jumps that mostly stay inside one
+// bitmap container, so the timed path is bitmap.nextGeq (the word-masked scan
+// this PR adds) rather than the array fast path.
+func BenchmarkNextGeqBitmap(b *testing.B) {
+	bm := bitmapContainerFixture()
+	max := uint64(16 << 16)
+	rng := rand.New(rand.NewSource(9))
+	gaps := make([]uint64, 1<<16)
+	for i := range gaps {
+		gaps[i] = uint64(rng.Intn(2000) + 1)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	cur := bm.NewContainsCursor()
+	x := uint64(0)
+	var s int
+	for i := 0; i < b.N; i++ {
+		v, ok := cur.NextGeq(x)
+		if !ok {
+			cur.Reset(bm)
+			x = 0
+			continue
+		}
+		s++
+		x = v + gaps[i&(1<<16-1)]
+		if x >= max {
+			cur.Reset(bm)
+			x = 0
+		}
+	}
+	sink = s
+}
+
+// BenchmarkNextGeqCrossContainer is a genuine cross-container leapfrog: jumps
+// far larger than a container's 65536 span, so every probe changes key and
+// exercises the keys searchFrom gallop plus the fresh-container walk (including
+// skips over mixedBitmap's empty-key gaps) rather than any same-container path.
+func BenchmarkNextGeqCrossContainer(b *testing.B) {
+	bm := mixedBitmap()
+	max := uint64(90 << 16)
+	rng := rand.New(rand.NewSource(9))
+	gaps := make([]uint64, 1<<16)
+	for i := range gaps {
+		gaps[i] = uint64(1<<16) + uint64(rng.Intn(3<<16)) // 1-4 containers forward
 	}
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/contains_cursor_nextgeq_test.go
+++ b/contains_cursor_nextgeq_test.go
@@ -1,0 +1,194 @@
+package sroar
+
+import (
+	"math/rand"
+	"sort"
+	"sync"
+	"testing"
+)
+
+var (
+	denseValsOnce sync.Once
+	denseVals     []uint64
+	mixedValsOnce sync.Once
+	mixedVals     []uint64
+)
+
+func denseValues() []uint64 {
+	denseValsOnce.Do(func() { denseVals = denseBitmap().ToArray() })
+	return denseVals
+}
+
+func mixedValues() []uint64 {
+	mixedValsOnce.Do(func() { mixedVals = mixedBitmap().ToArray() })
+	return mixedVals
+}
+
+func refNextGeq(vals []uint64, x uint64) (uint64, bool) {
+	i := sort.Search(len(vals), func(i int) bool { return vals[i] >= x })
+	if i < len(vals) {
+		return vals[i], true
+	}
+	return 0, false
+}
+
+// NextGeq must return the exact successor for any probe, in any order, on both
+// array and bitmap containers.
+func TestNextGeqEquivalence(t *testing.T) {
+	fixtures := []struct {
+		name string
+		bm   *Bitmap
+		vals []uint64
+		max  uint64
+	}{
+		{"dense_arrays", denseBitmap(), denseValues(), 200_000_000},
+		{"mixed_containers", mixedBitmap(), mixedValues(), 90 << 16},
+	}
+	for _, fx := range fixtures {
+		t.Run(fx.name, func(t *testing.T) {
+			rng := rand.New(rand.NewSource(31))
+
+			// leapfrog: ascending probes jumping from each successor
+			cur := fx.bm.NewContainsCursor()
+			x := uint64(0)
+			for x < fx.max {
+				got, gotOK := cur.NextGeq(x)
+				want, wantOK := refNextGeq(fx.vals, x)
+				if gotOK != wantOK || got != want {
+					t.Fatalf("leapfrog NextGeq(%d) = (%d,%v), want (%d,%v)", x, got, gotOK, want, wantOK)
+				}
+				if !gotOK {
+					break
+				}
+				if !cur.Contains(got) { // returned value must be set, cursor stays consistent
+					t.Fatalf("Contains(NextGeq(%d)=%d) = false", x, got)
+				}
+				x = got + 1 + uint64(rng.Intn(100_000))
+			}
+
+			// random probes on a shared cursor (forward and backward jumps)
+			cur2 := fx.bm.NewContainsCursor()
+			for i := 0; i < 300_000; i++ {
+				x := uint64(rng.Int63n(int64(fx.max)))
+				got, gotOK := cur2.NextGeq(x)
+				want, wantOK := refNextGeq(fx.vals, x)
+				if gotOK != wantOK || got != want {
+					t.Fatalf("random NextGeq(%d) = (%d,%v), want (%d,%v)", x, got, gotOK, want, wantOK)
+				}
+			}
+
+			// interleaved Contains + NextGeq, ascending: both must stay exact
+			cur3 := fx.bm.NewContainsCursor()
+			x = 0
+			for i := 0; i < 200_000 && x < fx.max; i++ {
+				if i%3 == 0 {
+					got, gotOK := cur3.NextGeq(x)
+					want, wantOK := refNextGeq(fx.vals, x)
+					if gotOK != wantOK || got != want {
+						t.Fatalf("interleaved NextGeq(%d) = (%d,%v), want (%d,%v)", x, got, gotOK, want, wantOK)
+					}
+				} else {
+					want, _ := refNextGeq(fx.vals, x)
+					if got := cur3.Contains(x); got != (want == x) {
+						t.Fatalf("interleaved Contains(%d) = %v, want %v", x, got, want == x)
+					}
+				}
+				x += uint64(rng.Intn(200) + 1)
+			}
+
+			// exact boundaries
+			first, last := fx.vals[0], fx.vals[len(fx.vals)-1]
+			cur4 := fx.bm.NewContainsCursor()
+			if v, ok := cur4.NextGeq(0); !ok || v != first {
+				t.Fatalf("NextGeq(0) = (%d,%v), want (%d,true)", v, ok, first)
+			}
+			if v, ok := cur4.NextGeq(last); !ok || v != last {
+				t.Fatalf("NextGeq(last) = (%d,%v), want (%d,true)", v, ok, last)
+			}
+			if _, ok := cur4.NextGeq(last + 1); ok {
+				t.Fatal("NextGeq(last+1) must not find a successor")
+			}
+		})
+	}
+}
+
+func TestNextGeqEdgeCases(t *testing.T) {
+	t.Run("nil_and_empty", func(t *testing.T) {
+		var nilCur *ContainsCursor
+		if _, ok := nilCur.NextGeq(0); ok {
+			t.Fatal("nil cursor")
+		}
+		if _, ok := NewBitmap().NewContainsCursor().NextGeq(0); ok {
+			t.Fatal("empty bitmap")
+		}
+	})
+	t.Run("skips_emptied_container", func(t *testing.T) {
+		b := NewBitmap()
+		b.Set(5)
+		b.Remove(5) // key-0 container remains, empty
+		b.Set(1<<16 + 3)
+		cur := b.NewContainsCursor()
+		if v, ok := cur.NextGeq(0); !ok || v != 1<<16+3 {
+			t.Fatalf("NextGeq(0) = (%d,%v), want (%d,true)", v, ok, 1<<16+3)
+		}
+	})
+	t.Run("crosses_container_gap", func(t *testing.T) {
+		b := NewBitmap()
+		b.Set(100)
+		b.Set(7<<16 + 9) // keys 0 and 7, nothing between
+		cur := b.NewContainsCursor()
+		if v, ok := cur.NextGeq(101); !ok || v != 7<<16+9 {
+			t.Fatalf("NextGeq(101) = (%d,%v)", v, ok)
+		}
+	})
+	t.Run("within_bitmap_container", func(t *testing.T) {
+		b := NewBitmap()
+		for x := uint64(0); x < 65536; x += 7 {
+			b.Set(x) // dense: bitmap container
+		}
+		vals := b.ToArray()
+		cur := b.NewContainsCursor()
+		rng := rand.New(rand.NewSource(3))
+		for i := 0; i < 100_000; i++ {
+			x := uint64(rng.Intn(65600))
+			got, gotOK := cur.NextGeq(x)
+			want, wantOK := refNextGeq(vals, x)
+			if gotOK != wantOK || got != want {
+				t.Fatalf("NextGeq(%d) = (%d,%v), want (%d,%v)", x, got, gotOK, want, wantOK)
+			}
+		}
+	})
+}
+
+// Leapfrog successor scan: the sparse-filter iteration pattern NextGeq exists
+// for (jump, land, jump), vs re-probing candidates one by one with Contains.
+func BenchmarkNextGeqLeapfrog(b *testing.B) {
+	bm := denseBitmap()
+	max := uint64(200_000_000)
+	rng := rand.New(rand.NewSource(9))
+	// precompute jump offsets to keep RNG out of the timed loop
+	gaps := make([]uint64, 1<<16)
+	for i := range gaps {
+		gaps[i] = uint64(rng.Intn(2000) + 1)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	cur := bm.NewContainsCursor()
+	x := uint64(0)
+	var s int
+	for i := 0; i < b.N; i++ {
+		v, ok := cur.NextGeq(x)
+		if !ok {
+			cur.Reset(bm)
+			x = 0
+			continue
+		}
+		s++
+		x = v + gaps[i&(1<<16-1)]
+		if x >= max {
+			cur.Reset(bm)
+			x = 0
+		}
+	}
+	sink = s
+}

--- a/contains_cursor_test.go
+++ b/contains_cursor_test.go
@@ -257,3 +257,48 @@ func BenchmarkContainsCursor(b *testing.B) {
 }
 
 var sink int
+
+// The reject-walk probe shapes: misses landing in the gap at the cursor and
+// re-probes of the value the cursor sits on. Both are arrayHas early returns —
+// one compare, no arrPos store — and regress first if that fast path is lost.
+func BenchmarkContainsCursorGapShapes(b *testing.B) {
+	bm := NewBitmap()
+	for x := uint64(0); x < 8<<16; x += 17 { // ~3855/container: array containers
+		bm.Set(x)
+	}
+	max := uint64(8 << 16)
+
+	b.Run("gap_reject", func(b *testing.B) {
+		cur := bm.NewContainsCursor()
+		var s int
+		y := uint64(1)
+		for i := 0; i < b.N; i++ {
+			if cur.Contains(y) { // 17k+1: always a miss in the gap ahead
+				s++
+			}
+			y += 17
+			if y >= max {
+				y = 1
+			}
+		}
+		sink = s
+	})
+	b.Run("at_cursor_hit", func(b *testing.B) {
+		cur := bm.NewContainsCursor()
+		var s int
+		y := uint64(0)
+		for i := 0; i < b.N; i += 2 {
+			if cur.Contains(y) { // advance to y (hit)
+				s++
+			}
+			if cur.Contains(y) { // re-probe the cursor position (hit)
+				s++
+			}
+			y += 17
+			if y >= max {
+				y = 0
+			}
+		}
+		sink = s
+	})
+}


### PR DESCRIPTION
Adds `NextGeq(x) (uint64, bool)` to `ContainsCursor`: the smallest set value ≥ x, resolved from the cursor's existing cache and leaving the cursor positioned on the result — so interleaved `Contains`/`NextGeq` with non-decreasing arguments stay on their fast paths. Follows up #44; independent of #45/#46.

## Why

This is the successor primitive for **leapfrog intersection**. Downstream (Weaviate BM25 filtered search), the merged tombstone+filter bitmap keeps only 2–8% of docs on update-heavy segments; the scan currently walks posting lists candidate by candidate and probes the filter on each (~49% of the filtered query loop, at the per-probe memory floor). With `NextGeq`, the roles invert when the filter is sparse: jump straight to the filter's next admissible docID and advance the posting lists to it — skipping the reject walks and, when postings are dense relative to the filter, whole block decodes. Verified planning estimate for that wiring: 19–41% of the filtered query loop.

## How

- Resolution reuses the `Contains` machinery unchanged: same-key cache, `maxKey` short-circuit, `searchFrom` gallop forward, plain search on backward jumps.
- Walks forward past empty (or unknown-type) containers; for containers after x's own, the successor is the container's minimum.
- New `bitmap.nextGeq(y)`: word-masked scan for the next set bit at or after a position (mask `0xFFFF >> (y & 0xF)` matches the MSB-first bit order used by `bitmapMask` and the iterator).
- On success the cursor state is updated to the returned value's container/position (preserving the lower-bound invariants); on "no successor" the state is left untouched.

## Verification

Differential against a `sort.Search` reference over `ToArray()` on both fixture shapes (~600K probes each): leapfrog ascending, fully random (forward + backward jumps), interleaved with `Contains`, and exact boundary probes (first/last/beyond). Edge cases: nil cursor/bitmap, empty bitmap, emptied container skipped, container-gap crossing, dense bitmap-container scans. Race-clean; full suite green.

## Benchmark

```
BenchmarkNextGeqLeapfrog-14    18.5 ns per successor jump    0 B/op    0 allocs/op
```

(dense fixture, ascending jumps with random 1–2000 gaps — the sparse-filter iteration pattern)
