### PR TITLE
add Accumulator: dense-staging N-way OR of many bitmaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ vendor/
 .idea/
 .vscode/
 
+.claude/
+
 testdata/bitmaps/**/

--- a/accumulator.go
+++ b/accumulator.go
@@ -8,15 +8,17 @@ import "math/bits"
 // structural container merge per source — for array containers that is an
 // O(container size) memmove to insert even a single element, which makes
 // N-way unions of near-singleton bitmaps quadratic in the source count. The
-// accumulator makes every deposit O(1): each touched 64K key range gets one
-// fixed-size dense staging block (the 64K bits of that range), array-container
-// sources set bits directly, bitmap-container sources OR in word-wise, and
-// the final roaring bitmap is allocated at its exact size and assembled once
-// by Bitmap, BitmapToBuf or InitBitmapToBuf.
+// accumulator makes every deposit O(1) by staging each touched 64K key
+// range in one fixed-size dense block, then assembling the exact-size
+// result once (Bitmap, BitmapToBuf or InitBitmapToBuf).
 //
 // Total cost is O(total input elements + touched key ranges); staging memory
 // is one 8KB block per touched key range (proportional to the spread of the
-// result, not to the number of sources).
+// result, not to the number of sources). Within one source, keys ascend, so
+// its new ranges append cheaply; across sources, each new range that
+// arrives out of order pays an O(existing ranges) insertion shift, so
+// unions spanning many ranges fed from unsorted sources approach
+// O(ranges²) in that term.
 //
 // Usage:
 //
@@ -201,10 +203,10 @@ func (acc *Accumulator) BitmapToBuf(get func(sizeBytes int) []byte) *Bitmap {
 // struct together with its buffer: get returns both — typically from one
 // pool entry — and the union is built into them, so a warm accumulator
 // building into pooled memory allocates nothing. The struct must be
-// non-nil; its previous content is discarded, never freed — it must not
-// own anything the caller still needs (the InitCloneToBuf contract). If
-// the buffer is too small it is left untouched and the struct is instead
-// set to a union built on the heap.
+// non-nil; its previous fields are overwritten, never freed — it must not
+// own anything the caller still needs. If the buffer is too small it is
+// left untouched and the struct is instead set to a union built on the
+// heap.
 func (acc *Accumulator) InitBitmapToBuf(get func(sizeBytes int) (*Bitmap, []byte)) *Bitmap {
 	var scratch [layoutScratchLen]int
 	cards, newKeys, sizeInitial, sizeContainers := acc.layout(scratch[:])

--- a/accumulator.go
+++ b/accumulator.go
@@ -1,0 +1,322 @@
+package sroar
+
+import "math/bits"
+
+// Accumulator combines many bitmaps into one by depositing their elements
+// into dense per-key staging containers instead of merging roaring
+// structures pairwise. Merging N tiny bitmaps via Or/FastOr costs a
+// structural container merge per source — for array containers that is an
+// O(container size) memmove to insert even a single element, which makes
+// N-way unions of near-singleton bitmaps quadratic in the source count. The
+// accumulator makes every deposit O(1): each touched 64K key range gets one
+// fixed-size dense staging block (the 64K bits of that range), array-container
+// sources set bits directly, bitmap-container sources OR in word-wise, and
+// the final roaring bitmap is allocated at its exact size and assembled once
+// by Bitmap, BitmapToBuf or InitBitmapToBuf.
+//
+// Total cost is O(total input elements + touched key ranges); staging memory
+// is one 8KB block per touched key range (proportional to the spread of the
+// result, not to the number of sources).
+//
+// Usage:
+//
+//	acc := NewAccumulator()
+//	for _, bm := range sources {
+//		acc.Or(bm)
+//	}
+//	result := acc.Bitmap()
+//
+// Or never retains its argument, so callers may release or reuse a source's
+// memory as soon as Or returns. The zero Accumulator is not usable; create
+// one with NewAccumulator. An Accumulator is not safe for concurrent use.
+type Accumulator struct {
+	// keys holds the touched 64K-range keys in ascending order; blocks is
+	// parallel to it. Each block is a headerless 4096-uint16 payload — the
+	// 64K bits of its range in bitmap-container bit order (bitmapMask), but
+	// without the container metadata, which only the final containers need.
+	// No cardinality is maintained during Or; it is computed once (via
+	// popcount) when the result is built.
+	keys   []uint64
+	blocks [][]uint16
+
+	// free holds cleared spare blocks carried across Reset (at most
+	// maxRetainedBlocks). Unlike blocks, entries are not bound to any key:
+	// the next union's ranges — whatever they are — claim them before
+	// allocating anew.
+	free [][]uint16
+
+	// lastIdx caches the most recently hit index into keys/blocks: sources
+	// frequently cluster in one range (and single-container sources under a
+	// small doc-ID universe hit very few ranges), so checking it first
+	// skips the binary search on runs of same-range deposits.
+	lastIdx int
+}
+
+func NewAccumulator() *Accumulator {
+	return &Accumulator{lastIdx: -1}
+}
+
+// block returns the staging container for the 64K range of key, creating it
+// on first touch.
+func (acc *Accumulator) block(key uint64) []uint16 {
+	if acc.lastIdx >= 0 && acc.keys[acc.lastIdx] == key {
+		return acc.blocks[acc.lastIdx]
+	}
+
+	// Binary search over the sorted keys.
+	lo, hi := 0, len(acc.keys)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if acc.keys[mid] < key {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	if lo < len(acc.keys) && acc.keys[lo] == key {
+		acc.lastIdx = lo
+		return acc.blocks[lo]
+	}
+
+	// New range: insert at lo, keeping keys sorted. Ranges are few (they
+	// track the spread of the union, not the number of sources), so the
+	// insertion copy is rare and small.
+	var b []uint16
+	if n := len(acc.free) - 1; n >= 0 {
+		// Take a spare; nil the vacated slot so the backing array never
+		// keeps a claimed block reachable on its own.
+		b, acc.free[n], acc.free = acc.free[n], nil, acc.free[:n]
+	} else {
+		b = make([]uint16, maxContainerSize-int(startIdx))
+	}
+	acc.keys = append(acc.keys, 0)
+	acc.blocks = append(acc.blocks, nil)
+	copy(acc.keys[lo+1:], acc.keys[lo:])
+	copy(acc.blocks[lo+1:], acc.blocks[lo:])
+	acc.keys[lo] = key
+	acc.blocks[lo] = b
+	acc.lastIdx = lo
+	return b
+}
+
+// Or deposits all elements of bm into the accumulator. bm is only read,
+// never retained: it may be released or reused as soon as Or returns.
+func (acc *Accumulator) Or(bm *Bitmap) {
+	if bm == nil {
+		return
+	}
+	n := bm.keys.numKeys()
+	for i := 0; i < n; i++ {
+		src := bm.getContainer(bm.keys.val(i))
+		if getCardinality(src) == 0 {
+			continue
+		}
+		dst := acc.block(bm.keys.key(i))
+		switch src[indexType] {
+		case typeArray:
+			for _, lo := range array(src).all() {
+				dst[lo>>4] |= bitmapMask[lo&0xF]
+			}
+		case typeBitmap:
+			d64 := uint16To64SliceUnsafe(dst)
+			s64 := uint16To64SliceUnsafe(src[startIdx:maxContainerSize])
+			for j, w := range s64 {
+				d64[j] |= w
+			}
+		}
+	}
+}
+
+// layoutScratchLen is how many per-block cardinalities the build path can
+// hold on the caller's stack. Unions spanning more ranges pay one heap
+// allocation for the slice.
+const layoutScratchLen = 64
+
+// layout runs the popcount pass over the staging blocks, fixing the
+// result's complete layout — per-block cardinalities and the derived key
+// and container space needs — so builds can allocate fully sized up front
+// and never reallocate or move anything. cards is scratch[:len(blocks)]
+// when it fits, a fresh slice otherwise. sizeInitial is the pre-created
+// key-0 container's size — exact when the union touches key 0, a
+// minContainerSize placeholder otherwise; sizeContainers covers all
+// remaining containers.
+func (acc *Accumulator) layout(scratch []int) (cards []int, newKeys, sizeInitial, sizeContainers int) {
+	if len(acc.blocks) <= len(scratch) {
+		cards = scratch[:len(acc.blocks)]
+	} else {
+		cards = make([]int, len(acc.blocks))
+	}
+	sizeInitial = minContainerSize
+	for i, b := range acc.blocks {
+		card := 0
+		for _, w := range uint16To64SliceUnsafe(b) {
+			card += bits.OnesCount64(w)
+		}
+		cards[i] = card
+		if card == 0 {
+			continue
+		}
+		sz, _ := containerSizeForCard(card)
+		if acc.keys[i] != 0 {
+			newKeys++
+			sizeContainers += int(sz)
+		} else {
+			// Key 0 is special-cased: every fresh bitmap pre-creates its
+			// key-0 slot and container (the node cannot tell a zero key
+			// from an empty slot), so instead of counting a new key and
+			// appending a duplicate container, the pre-created one is made
+			// exactly this size and filled in place by buildInto.
+			sizeInitial = int(sz)
+		}
+	}
+	return cards, newKeys, sizeInitial, sizeContainers
+}
+
+// Bitmap assembles and returns the union. The accumulator keeps its staging
+// state afterwards; call Reset to reuse it for a new union.
+func (acc *Accumulator) Bitmap() *Bitmap {
+	var scratch [layoutScratchLen]int
+	cards, newKeys, sizeInitial, sizeContainers := acc.layout(scratch[:])
+	ra := initBitmapWithCap(&Bitmap{}, newKeys+2, sizeInitial, sizeContainers)
+	acc.buildInto(ra, cards)
+	return ra
+}
+
+// BitmapToBuf assembles the union into a buffer obtained from get — for
+// callers that pool result memory — and returns a bitmap backed by it. get
+// is called exactly once, with the exact required size in bytes, and must
+// not itself use the accumulator. A returned buffer with insufficient
+// capacity is left untouched and the union is built on the heap instead.
+// The returned bitmap holds a reference to the buffer, so the buffer must
+// not be reused until the bitmap is released. Mutating the result stays
+// within the buffer's capacity until it needs to grow, at which point it
+// migrates to the heap.
+func (acc *Accumulator) BitmapToBuf(get func(sizeBytes int) []byte) *Bitmap {
+	return acc.InitBitmapToBuf(func(sizeBytes int) (*Bitmap, []byte) {
+		return &Bitmap{}, get(sizeBytes)
+	})
+}
+
+// InitBitmapToBuf is BitmapToBuf for callers that pool the result Bitmap
+// struct together with its buffer: get returns both — typically from one
+// pool entry — and the union is built into them, so a warm accumulator
+// building into pooled memory allocates nothing. The struct must be
+// non-nil; its previous content is discarded, never freed — it must not
+// own anything the caller still needs (the InitCloneToBuf contract). If
+// the buffer is too small it is left untouched and the struct is instead
+// set to a union built on the heap.
+func (acc *Accumulator) InitBitmapToBuf(get func(sizeBytes int) (*Bitmap, []byte)) *Bitmap {
+	var scratch [layoutScratchLen]int
+	cards, newKeys, sizeInitial, sizeContainers := acc.layout(scratch[:])
+	// The +2 keys are the always-present key 0 and the spare buildInto
+	// relies on.
+	keysLen := calcInitialKeysLen(newKeys + 2)
+	need := keysLen + sizeInitial + sizeContainers
+
+	dst, buf := get(need * 2)
+	// Same even-capacity view as NewBitmapToBuf: the bitmap operates on
+	// []uint16 (2 bytes per element).
+	buf = buf[:cap(buf)/2*2]
+	if len(buf)/2 < need {
+		ra := initBitmapWithCap(&Bitmap{}, newKeys+2, sizeInitial, sizeContainers)
+		acc.buildInto(ra, cards)
+		*dst = *ra
+		return dst
+	}
+	bufU16 := byteToUint16SliceUnsafe(buf)
+
+	// Pooled buffers arrive dirty. The build writes every byte the result
+	// exposes — container headers and payloads in full, array-container
+	// padding cleared in buildInto — except the keys node's unused slots,
+	// which are cleared here so the serialized form stays deterministic.
+	clear(bufU16[:keysLen])
+
+	initBitmapCore(dst, keysLen, sizeInitial, bufU16)
+	dst._ptr = buf // Keep a GC reference to buf, mirroring NewBitmapToBuf.
+	acc.buildInto(dst, cards)
+	return dst
+}
+
+// buildInto builds the result containers into ra, whose data slab must
+// already have capacity for the full layout and whose keys node must be
+// sized with one spare slot beyond the result's keys (the newKeys+2 at the
+// call sites): setKey's return (a possibly shifted offset) is discarded
+// below, which is safe only because the spare keeps the node from ever
+// filling mid-build, so setKey never expands the node or moves containers.
+// Containers are built in ascending key order (acc.keys is sorted), so
+// each is appended once and never moved, and no append can reallocate.
+func (acc *Accumulator) buildInto(ra *Bitmap, cards []int) {
+	for i, b := range acc.blocks {
+		card := cards[i]
+		if card == 0 {
+			continue
+		}
+		sz, typ := containerSizeForCard(card)
+		var off uint64
+		if acc.keys[i] == 0 {
+			// Key 0's container pre-exists at exactly sz (layout sized it
+			// via sizeInitial) with its key slot already set — fill it in
+			// place; appending would orphan it as dead slab space.
+			off = ra.keys.val(0)
+		} else {
+			off = ra.newContainerNoClr(sz)
+			ra.data[off] = sz
+		}
+		c := ra.getContainer(off)
+		c[indexType] = typ
+		setCardinality(c, card)
+		if typ == typeArray {
+			bitsIntoArray(b, c[startIdx:])
+			// The padding tail is never read by lookups, but ToBuffer
+			// serializes the whole slab — clear it so a dirty pooled buffer
+			// cannot leak into the serialized bytes.
+			clear(c[int(startIdx)+card:])
+		} else {
+			copy(c[startIdx:], b)
+		}
+		if acc.keys[i] != 0 {
+			ra.setKey(acc.keys[i], off)
+		}
+	}
+}
+
+// maxRetainedBlocks bounds the staging blocks Reset carries over to the
+// next union as spares: enough to serve typical pooled reuse without
+// re-allocating, while capping a long-lived accumulator's footprint (and
+// Reset's clearing cost) at maxRetainedBlocks * 8KB no matter how many
+// ranges past unions touched.
+const maxRetainedBlocks = 16
+
+// maxRetainedSlots bounds the capacity of the keys/blocks slices kept
+// across Reset. Their per-entry cost is tiny next to the 8KB blocks, but a
+// single union over an abnormal number of ranges would otherwise pin its
+// full-size backing arrays for the accumulator's lifetime.
+const maxRetainedSlots = 1024
+
+// Reset clears the accumulator for reuse. Up to maxRetainedBlocks staging
+// blocks are cleared and kept as key-independent spares for the next
+// union's ranges, whatever they are; everything else is released, so a
+// pooled accumulator's memory and per-union cost stay bounded by the
+// current union, not by every range it has ever served.
+func (acc *Accumulator) Reset() {
+	if acc.free == nil {
+		acc.free = make([][]uint16, 0, maxRetainedBlocks)
+	}
+	for _, b := range acc.blocks {
+		if len(acc.free) == maxRetainedBlocks {
+			break
+		}
+		clear(b)
+		acc.free = append(acc.free, b)
+	}
+	if cap(acc.keys) > maxRetainedSlots {
+		acc.keys, acc.blocks = nil, nil
+	} else {
+		// Zero the pointer slots before truncating: a bare [:0] would keep
+		// every dropped block reachable through the backing array.
+		clear(acc.blocks)
+		acc.keys = acc.keys[:0]
+		acc.blocks = acc.blocks[:0]
+	}
+	acc.lastIdx = -1
+}

--- a/accumulator.go
+++ b/accumulator.go
@@ -1,6 +1,10 @@
 package sroar
 
-import "math/bits"
+import (
+	"fmt"
+	"math/bits"
+	"slices"
+)
 
 // Accumulator combines many bitmaps into one by depositing their elements
 // into dense per-key staging containers instead of merging roaring
@@ -12,13 +16,17 @@ import "math/bits"
 // range in one fixed-size dense block, then assembling the exact-size
 // result once (Bitmap, BitmapToBuf or InitBitmapToBuf).
 //
-// Total cost is O(total input elements + touched key ranges); staging memory
-// is one 8KB block per touched key range (proportional to the spread of the
-// result, not to the number of sources). Within one source, keys ascend, so
-// its new ranges append cheaply; across sources, each new range that
-// arrives out of order pays an O(existing ranges) insertion shift, so
-// unions spanning many ranges fed from unsorted sources approach
-// O(ranges²) in that term.
+// Total cost is O(total input elements + touched key ranges); staging
+// memory is one 8KB block per touched key range (proportional to the
+// spread of the result, not to the number of sources). In the sparse
+// extreme — every element in its own range — that degrades to ~8KB per
+// element, staging orders of magnitude more memory than the result it
+// builds; FastOr or sort+FromSortedList are the better tools there. Reset
+// caps only what is retained between unions, never the peak during one.
+// Within one source, keys ascend, so its new ranges append cheaply; across
+// sources, each new range that arrives out of order pays an O(existing
+// ranges) insertion shift, so unions spanning many ranges fed from
+// unsorted sources approach O(ranges²) in that term.
 //
 // Usage:
 //
@@ -29,8 +37,9 @@ import "math/bits"
 //	result := acc.Bitmap()
 //
 // Or never retains its argument, so callers may release or reuse a source's
-// memory as soon as Or returns. The zero Accumulator is not usable; create
-// one with NewAccumulator. An Accumulator is not safe for concurrent use.
+// memory as soon as Or returns. The zero Accumulator is ready to use;
+// NewAccumulator is equivalent. An Accumulator is not safe for concurrent
+// use.
 type Accumulator struct {
 	// keys holds the touched 64K-range keys in ascending order; blocks is
 	// parallel to it. Each block is a headerless 4096-uint16 payload — the
@@ -52,30 +61,26 @@ type Accumulator struct {
 	// small doc-ID universe hit very few ranges), so checking it first
 	// skips the binary search on runs of same-range deposits.
 	lastIdx int
+
+	// gen counts mutations (Or, Reset). Builds compare it across the get
+	// callback to catch a get that uses the accumulator mid-build — the
+	// layout snapshot would no longer match the staged bits.
+	gen uint64
 }
 
 func NewAccumulator() *Accumulator {
-	return &Accumulator{lastIdx: -1}
+	return &Accumulator{}
 }
 
 // block returns the staging container for the 64K range of key, creating it
 // on first touch.
 func (acc *Accumulator) block(key uint64) []uint16 {
-	if acc.lastIdx >= 0 && acc.keys[acc.lastIdx] == key {
+	if acc.lastIdx < len(acc.keys) && acc.keys[acc.lastIdx] == key {
 		return acc.blocks[acc.lastIdx]
 	}
 
-	// Binary search over the sorted keys.
-	lo, hi := 0, len(acc.keys)
-	for lo < hi {
-		mid := (lo + hi) / 2
-		if acc.keys[mid] < key {
-			lo = mid + 1
-		} else {
-			hi = mid
-		}
-	}
-	if lo < len(acc.keys) && acc.keys[lo] == key {
+	lo, found := slices.BinarySearch(acc.keys, key)
+	if found {
 		acc.lastIdx = lo
 		return acc.blocks[lo]
 	}
@@ -107,6 +112,7 @@ func (acc *Accumulator) Or(bm *Bitmap) {
 	if bm == nil {
 		return
 	}
+	acc.gen++
 	n := bm.keys.numKeys()
 	for i := 0; i < n; i++ {
 		src := bm.getContainer(bm.keys.val(i))
@@ -125,6 +131,8 @@ func (acc *Accumulator) Or(bm *Bitmap) {
 			for j, w := range s64 {
 				d64[j] |= w
 			}
+		default:
+			panic("Accumulator.Or: unknown container type")
 		}
 	}
 }
@@ -134,7 +142,7 @@ func (acc *Accumulator) Or(bm *Bitmap) {
 // allocation for the slice.
 const layoutScratchLen = 64
 
-// layout runs the popcount pass over the staging blocks, fixing the
+// layout runs the popcount pass over the staging blocks, determining the
 // result's complete layout — per-block cardinalities and the derived key
 // and container space needs — so builds can allocate fully sized up front
 // and never reallocate or move anything. cards is scratch[:len(blocks)]
@@ -187,12 +195,15 @@ func (acc *Accumulator) Bitmap() *Bitmap {
 // BitmapToBuf assembles the union into a buffer obtained from get — for
 // callers that pool result memory — and returns a bitmap backed by it. get
 // is called exactly once, with the exact required size in bytes, and must
-// not itself use the accumulator. A returned buffer with insufficient
-// capacity is left untouched and the union is built on the heap instead.
-// The returned bitmap holds a reference to the buffer, so the buffer must
-// not be reused until the bitmap is released. Mutating the result stays
-// within the buffer's capacity until it needs to grow, at which point it
-// migrates to the heap.
+// not itself use the accumulator (doing so panics). Returning a buffer
+// smaller than the requested size panics — the caller was told exactly how
+// much is needed.
+// The buffer is adopted to its full capacity (rounded down to even), not
+// just its length — a length-limited view of a larger backing array hands
+// the whole backing array to the result. The returned bitmap holds a
+// reference to the buffer, so the buffer must not be reused until the
+// bitmap is released. Mutating the result stays within the buffer's
+// capacity until it needs to grow, at which point it migrates to the heap.
 func (acc *Accumulator) BitmapToBuf(get func(sizeBytes int) []byte) *Bitmap {
 	return acc.InitBitmapToBuf(func(sizeBytes int) (*Bitmap, []byte) {
 		return &Bitmap{}, get(sizeBytes)
@@ -204,9 +215,8 @@ func (acc *Accumulator) BitmapToBuf(get func(sizeBytes int) []byte) *Bitmap {
 // pool entry — and the union is built into them, so a warm accumulator
 // building into pooled memory allocates nothing. The struct must be
 // non-nil; its previous fields are overwritten, never freed — it must not
-// own anything the caller still needs. If the buffer is too small it is
-// left untouched and the struct is instead set to a union built on the
-// heap.
+// own anything the caller still needs. A buffer smaller than the requested
+// size panics, as in BitmapToBuf.
 func (acc *Accumulator) InitBitmapToBuf(get func(sizeBytes int) (*Bitmap, []byte)) *Bitmap {
 	var scratch [layoutScratchLen]int
 	cards, newKeys, sizeInitial, sizeContainers := acc.layout(scratch[:])
@@ -215,15 +225,18 @@ func (acc *Accumulator) InitBitmapToBuf(get func(sizeBytes int) (*Bitmap, []byte
 	keysLen := calcInitialKeysLen(newKeys + 2)
 	need := keysLen + sizeInitial + sizeContainers
 
+	gen := acc.gen
 	dst, buf := get(need * 2)
+	if acc.gen != gen {
+		panic("Accumulator: mutated during build — get must not use the accumulator")
+	}
 	// Same even-capacity view as NewBitmapToBuf: the bitmap operates on
 	// []uint16 (2 bytes per element).
 	buf = buf[:cap(buf)/2*2]
 	if len(buf)/2 < need {
-		ra := initBitmapWithCap(&Bitmap{}, newKeys+2, sizeInitial, sizeContainers)
-		acc.buildInto(ra, cards)
-		*dst = *ra
-		return dst
+		// Report cap: it matches what the caller passed, and with need*2
+		// always even the rounded-down len could only confuse.
+		panic(fmt.Sprintf("Accumulator.InitBitmapToBuf: buf too small: need %d bytes, got %d", need*2, cap(buf)))
 	}
 	bufU16 := byteToUint16SliceUnsafe(buf)
 
@@ -239,7 +252,7 @@ func (acc *Accumulator) InitBitmapToBuf(get func(sizeBytes int) (*Bitmap, []byte
 	return dst
 }
 
-// buildInto builds the result containers into ra, whose data slab must
+// buildInto builds the result containers into ra, whose data array must
 // already have capacity for the full layout and whose keys node must be
 // sized with one spare slot beyond the result's keys (the newKeys+2 at the
 // call sites): setKey's return (a possibly shifted offset) is discarded
@@ -258,7 +271,7 @@ func (acc *Accumulator) buildInto(ra *Bitmap, cards []int) {
 		if acc.keys[i] == 0 {
 			// Key 0's container pre-exists at exactly sz (layout sized it
 			// via sizeInitial) with its key slot already set — fill it in
-			// place; appending would orphan it as dead slab space.
+			// place; appending would orphan it as dead space in ra.data.
 			off = ra.keys.val(0)
 		} else {
 			off = ra.newContainerNoClr(sz)
@@ -270,8 +283,8 @@ func (acc *Accumulator) buildInto(ra *Bitmap, cards []int) {
 		if typ == typeArray {
 			bitsIntoArray(b, c[startIdx:])
 			// The padding tail is never read by lookups, but ToBuffer
-			// serializes the whole slab — clear it so a dirty pooled buffer
-			// cannot leak into the serialized bytes.
+			// serializes the whole data array — clear it so a dirty pooled
+			// buffer cannot leak into the serialized bytes.
 			clear(c[int(startIdx)+card:])
 		} else {
 			copy(c[startIdx:], b)
@@ -299,8 +312,11 @@ const maxRetainedSlots = 1024
 // blocks are cleared and kept as key-independent spares for the next
 // union's ranges, whatever they are; everything else is released, so a
 // pooled accumulator's memory and per-union cost stay bounded by the
-// current union, not by every range it has ever served.
+// current union, not by every range it has ever served. Reset bounds
+// retained memory only — the peak during a union is whatever its spread
+// demands.
 func (acc *Accumulator) Reset() {
+	acc.gen++
 	if acc.free == nil {
 		acc.free = make([][]uint16, 0, maxRetainedBlocks)
 	}
@@ -320,5 +336,5 @@ func (acc *Accumulator) Reset() {
 		acc.keys = acc.keys[:0]
 		acc.blocks = acc.blocks[:0]
 	}
-	acc.lastIdx = -1
+	acc.lastIdx = 0
 }

--- a/accumulator_test.go
+++ b/accumulator_test.go
@@ -1,0 +1,451 @@
+package sroar
+
+import (
+	"math"
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// refUnion computes the expected union of all sources element-wise, entirely
+// independent of any sroar merge code.
+func refUnion(sources []*Bitmap) []uint64 {
+	seen := map[uint64]struct{}{}
+	for _, s := range sources {
+		for _, v := range s.ToArray() {
+			seen[v] = struct{}{}
+		}
+	}
+	out := make([]uint64, 0, len(seen))
+	for v := range seen {
+		out = append(out, v)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+func bitmapOf(vals ...uint64) *Bitmap {
+	bm := NewBitmap()
+	bm.SetMany(vals)
+	return bm
+}
+
+func TestAccumulator(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+
+	randomVals := func(n int, universe uint64) []uint64 {
+		vals := make([]uint64, n)
+		for i := range vals {
+			vals[i] = rng.Uint64() % universe
+		}
+		return vals
+	}
+
+	tests := []struct {
+		name    string
+		sources func() []*Bitmap
+	}{
+		{
+			name:    "no sources",
+			sources: func() []*Bitmap { return nil },
+		},
+		{
+			name:    "nil and empty sources only",
+			sources: func() []*Bitmap { return []*Bitmap{nil, NewBitmap(), nil} },
+		},
+		{
+			name: "single singleton",
+			sources: func() []*Bitmap {
+				return []*Bitmap{bitmapOf(123456)}
+			},
+		},
+		{
+			name: "many singletons small universe with duplicates",
+			sources: func() []*Bitmap {
+				sources := make([]*Bitmap, 10_000)
+				for i := range sources {
+					sources[i] = bitmapOf(rng.Uint64() % 300_000)
+				}
+				return sources
+			},
+		},
+		{
+			name: "many singletons spread universe",
+			sources: func() []*Bitmap {
+				sources := make([]*Bitmap, 5_000)
+				for i := range sources {
+					sources[i] = bitmapOf(rng.Uint64() % (1 << 40))
+				}
+				return sources
+			},
+		},
+		{
+			name: "small multi-element sources",
+			sources: func() []*Bitmap {
+				sources := make([]*Bitmap, 2_000)
+				for i := range sources {
+					sources[i] = bitmapOf(randomVals(1+rng.Intn(5), 1_000_000)...)
+				}
+				return sources
+			},
+		},
+		{
+			name: "few large sources",
+			sources: func() []*Bitmap {
+				sources := make([]*Bitmap, 5)
+				for i := range sources {
+					sources[i] = bitmapOf(randomVals(500_000, 10_000_000)...)
+				}
+				return sources
+			},
+		},
+		{
+			name: "mixed tiny and large",
+			sources: func() []*Bitmap {
+				sources := make([]*Bitmap, 0, 3_005)
+				for i := 0; i < 3_000; i++ {
+					sources = append(sources, bitmapOf(rng.Uint64()%10_000_000))
+				}
+				for i := 0; i < 5; i++ {
+					sources = append(sources, bitmapOf(randomVals(200_000, 10_000_000)...))
+				}
+				return sources
+			},
+		},
+		{
+			name: "key zero range",
+			sources: func() []*Bitmap {
+				return []*Bitmap{bitmapOf(0), bitmapOf(1), bitmapOf(65535), bitmapOf(65536)}
+			},
+		},
+		{
+			name: "top key range",
+			sources: func() []*Bitmap {
+				// The very last 64K range and the last values in it: the
+				// deposit path with lo == 0xFFFF and the largest possible key.
+				return []*Bitmap{
+					bitmapOf(math.MaxUint64),
+					bitmapOf(math.MaxUint64 - 1),
+					bitmapOf(math.MaxUint64 - 65536),
+					bitmapOf(0),
+				}
+			},
+		},
+		{
+			name: "array-bitmap cutoff below",
+			sources: func() []*Bitmap {
+				// 2048 distinct values in one 64K range: result container
+				// stays an array container.
+				sources := make([]*Bitmap, 2048)
+				for i := range sources {
+					sources[i] = bitmapOf(uint64(i) * 2)
+				}
+				return sources
+			},
+		},
+		{
+			name: "array-bitmap cutoff above",
+			sources: func() []*Bitmap {
+				// 2049 distinct values in one 64K range: result container
+				// becomes a bitmap container.
+				sources := make([]*Bitmap, 2049)
+				for i := range sources {
+					sources[i] = bitmapOf(uint64(i) * 2)
+				}
+				return sources
+			},
+		},
+		{
+			name: "full container",
+			sources: func() []*Bitmap {
+				vals := make([]uint64, 65536)
+				for i := range vals {
+					vals[i] = uint64(i)
+				}
+				return []*Bitmap{bitmapOf(vals...), bitmapOf(1, 2, 3)}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sources := tt.sources()
+			want := refUnion(sources)
+
+			acc := NewAccumulator()
+			for _, s := range sources {
+				acc.Or(s)
+			}
+			got := acc.Bitmap()
+
+			require.Equal(t, len(want), got.GetCardinality())
+			require.Equal(t, want, got.ToArray())
+		})
+	}
+}
+
+func TestAccumulatorReset(t *testing.T) {
+	acc := NewAccumulator()
+	acc.Or(bitmapOf(1, 2, 3))
+	acc.Or(bitmapOf(100_000, 200_000))
+	require.Equal(t, []uint64{1, 2, 3, 100_000, 200_000}, acc.Bitmap().ToArray())
+
+	// After Reset, nothing from the previous union may leak into the next;
+	// building right away yields an empty bitmap.
+	acc.Reset()
+	require.Equal(t, 0, acc.Bitmap().GetCardinality())
+	acc.Or(bitmapOf(42))
+	acc.Or(bitmapOf(300_000))
+	require.Equal(t, []uint64{42, 300_000}, acc.Bitmap().ToArray())
+}
+
+func TestAccumulatorResetRetainsSpareBlocks(t *testing.T) {
+	// Spares survive Reset key-independently: a following union over a
+	// completely different id range must reuse them instead of allocating.
+	acc := NewAccumulator()
+	acc.Or(bitmapOf(42))
+	spare := &acc.blocks[0][0]
+	acc.Reset()
+	acc.Or(bitmapOf(1 << 40))
+	require.Equal(t, spare, &acc.blocks[0][0])
+	require.Equal(t, []uint64{1 << 40}, acc.Bitmap().ToArray())
+
+	// Spare retention is capped: after a union over many ranges, only
+	// maxRetainedBlocks blocks may stay resident.
+	acc.Reset()
+	for i := 0; i < 100; i++ {
+		acc.Or(bitmapOf(uint64(i) << 16))
+	}
+	acc.Reset()
+	require.Empty(t, acc.keys)
+	require.LessOrEqual(t, len(acc.free), maxRetainedBlocks)
+	acc.Or(bitmapOf(5, 1<<16|7, 1<<40))
+	require.Equal(t, []uint64{5, 1<<16 | 7, 1 << 40}, acc.Bitmap().ToArray())
+
+	// The keys/blocks slices themselves are dropped once a union pushed
+	// their capacity past maxRetainedSlots.
+	acc.Reset()
+	for i := 0; i < maxRetainedSlots+1; i++ {
+		acc.Or(bitmapOf(uint64(i) << 16))
+	}
+	require.Equal(t, maxRetainedSlots+1, acc.Bitmap().GetCardinality())
+	acc.Reset()
+	require.Nil(t, acc.keys)
+	acc.Or(bitmapOf(7))
+	require.Equal(t, []uint64{7}, acc.Bitmap().ToArray())
+}
+
+func TestAccumulatorBitmapToBuf(t *testing.T) {
+	rng := rand.New(rand.NewSource(11))
+	sources := make([]*Bitmap, 20_000)
+	for i := range sources {
+		sources[i] = bitmapOf(rng.Uint64() % 300_000)
+	}
+	// Sparse singletons in high key ranges on top of the dense low range: the
+	// union then holds array containers (with padding tails) alongside bitmap
+	// containers, so the serialization subtests exercise both.
+	for i := 0; i < 64; i++ {
+		sources = append(sources, bitmapOf(uint64(i+10)<<16|uint64(i)))
+	}
+	want := refUnion(sources)
+
+	build := func() *Accumulator {
+		acc := NewAccumulator()
+		for _, s := range sources {
+			acc.Or(s)
+		}
+		return acc
+	}
+
+	t.Run("dirty pooled buffer", func(t *testing.T) {
+		acc := build()
+		var buf []byte
+		got := acc.BitmapToBuf(func(n int) []byte {
+			buf = make([]byte, n)
+			for i := range buf {
+				buf[i] = 0xFF // pooled buffers arrive dirty
+			}
+			return buf
+		})
+		require.Equal(t, want, got.ToArray())
+		// The result must actually live in the obtained buffer, not on the heap.
+		require.Equal(t, &buf[0], &got._ptr[0])
+	})
+
+	t.Run("too small falls back to heap", func(t *testing.T) {
+		acc := build()
+		got := acc.BitmapToBuf(func(int) []byte { return make([]byte, 16) })
+		require.Equal(t, want, got.ToArray())
+		require.Nil(t, got._ptr)
+	})
+
+	t.Run("one uint16 short falls back to heap", func(t *testing.T) {
+		// The requested size fits exactly (see "result occupies exactly the
+		// requested size"); one uint16 less must fall back and leave the
+		// buffer untouched.
+		acc := build()
+		var buf []byte
+		got := acc.BitmapToBuf(func(n int) []byte {
+			buf = make([]byte, n-2)
+			return buf
+		})
+		require.Equal(t, want, got.ToArray())
+		require.Nil(t, got._ptr)
+		require.Equal(t, make([]byte, len(buf)), buf)
+	})
+
+	t.Run("Or between builds is reflected", func(t *testing.T) {
+		acc := build()
+		var size, sizeGrown int
+		acc.BitmapToBuf(func(n int) []byte { size = n; return make([]byte, n) })
+		// Force a new range into existence: the requested size must grow.
+		acc.Or(bitmapOf(1 << 40))
+		got := acc.BitmapToBuf(func(n int) []byte { sizeGrown = n; return make([]byte, n) })
+		require.Greater(t, sizeGrown, size)
+		require.Equal(t, append(append([]uint64{}, want...), 1<<40), got.ToArray())
+	})
+
+	t.Run("result occupies exactly the requested size", func(t *testing.T) {
+		// The sources touch key 0, whose pre-created container must be
+		// filled in place rather than orphaned — any waste would make the
+		// serialized result smaller than the buffer it was built into.
+		acc := build()
+		var size int
+		got := acc.BitmapToBuf(func(n int) []byte { size = n; return make([]byte, n) })
+		require.Len(t, got.ToBuffer(), size)
+		require.Len(t, acc.Bitmap().ToBuffer(), size)
+	})
+
+	t.Run("result occupies exactly the requested size without key 0", func(t *testing.T) {
+		// A union that never touches key 0 keeps the pre-created key-0
+		// container as a minimum-size placeholder that is still part of the
+		// serialized slab.
+		acc := NewAccumulator()
+		for i := 1; i <= 40; i++ {
+			acc.Or(bitmapOf(uint64(i) << 16))
+		}
+		var size int
+		got := acc.BitmapToBuf(func(n int) []byte { size = n; return make([]byte, n) })
+		require.Len(t, got.ToBuffer(), size)
+		require.Len(t, acc.Bitmap().ToBuffer(), size)
+	})
+
+	t.Run("dirty buffer does not leak into serialized bytes", func(t *testing.T) {
+		// ToBuffer serializes the whole data slab, so every byte of the
+		// result — including array-container padding — must be independent
+		// of the buffer's prior contents.
+		serialize := func(fill byte) []byte {
+			acc := build()
+			return acc.BitmapToBuf(func(n int) []byte {
+				buf := make([]byte, n)
+				for i := range buf {
+					buf[i] = fill
+				}
+				return buf
+			}).ToBufferWithCopy()
+		}
+		require.Equal(t, serialize(0x00), serialize(0xFF))
+	})
+
+	t.Run("ToBuffer FromBuffer round-trip", func(t *testing.T) {
+		acc := build()
+		serialized := acc.BitmapToBuf(func(n int) []byte {
+			buf := make([]byte, n)
+			for i := range buf {
+				buf[i] = 0xFF
+			}
+			return buf
+		}).ToBufferWithCopy()
+		require.Equal(t, want, FromBuffer(serialized).ToArray())
+	})
+
+	t.Run("reset then rebuild into same buffer", func(t *testing.T) {
+		acc := build()
+		var buf []byte
+		grab := func(n int) []byte {
+			if cap(buf) < n {
+				buf = make([]byte, n)
+			}
+			return buf[:n]
+		}
+		require.Equal(t, want, acc.BitmapToBuf(grab).ToArray())
+		acc.Reset()
+		acc.Or(bitmapOf(7, 8, 9))
+		require.Equal(t, []uint64{7, 8, 9}, acc.BitmapToBuf(grab).ToArray())
+	})
+}
+
+func TestAccumulatorInitBitmapToBuf(t *testing.T) {
+	a := bitmapOf(1, 2, 3, 100_000)
+	b := bitmapOf(42, 1<<40)
+
+	t.Run("reuses struct and buffer across unions", func(t *testing.T) {
+		// One pool entry: the struct and the buffer live together and both
+		// must be reused on every build.
+		var bm Bitmap
+		buf := make([]byte, 4096)
+		get := func(n int) (*Bitmap, []byte) {
+			require.LessOrEqual(t, n, len(buf))
+			return &bm, buf
+		}
+
+		acc := NewAccumulator()
+		acc.Or(a)
+		got := acc.InitBitmapToBuf(get)
+		require.Same(t, &bm, got)
+		require.Equal(t, a.ToArray(), got.ToArray())
+		require.Equal(t, &buf[0], &got._ptr[0])
+
+		acc.Reset()
+		acc.Or(b)
+		got = acc.InitBitmapToBuf(get)
+		require.Same(t, &bm, got)
+		require.Equal(t, b.ToArray(), got.ToArray())
+		require.Equal(t, &buf[0], &got._ptr[0])
+	})
+
+	t.Run("too small sets the struct to a heap-built union", func(t *testing.T) {
+		var bm Bitmap
+		acc := NewAccumulator()
+		acc.Or(a)
+		got := acc.InitBitmapToBuf(func(int) (*Bitmap, []byte) {
+			return &bm, make([]byte, 16)
+		})
+		require.Same(t, &bm, got)
+		require.Equal(t, a.ToArray(), got.ToArray())
+		require.Nil(t, got._ptr)
+	})
+
+	t.Run("warm accumulator with pooled memory allocates nothing", func(t *testing.T) {
+		sources := []*Bitmap{bitmapOf(1, 2, 3), bitmapOf(70_000), bitmapOf(1 << 33)}
+		var bm Bitmap
+		buf := make([]byte, 4096)
+		get := func(int) (*Bitmap, []byte) { return &bm, buf }
+
+		acc := NewAccumulator()
+		allocs := testing.AllocsPerRun(100, func() {
+			acc.Reset()
+			for _, s := range sources {
+				acc.Or(s)
+			}
+			acc.InitBitmapToBuf(get)
+		})
+		require.Zero(t, allocs)
+	})
+}
+
+func TestAccumulatorResultIsMutable(t *testing.T) {
+	// The built bitmap must be a fully independent bitmap: mutating it must
+	// not corrupt the builder, and building again must not affect it.
+	acc := NewAccumulator()
+	acc.Or(bitmapOf(1, 2, 3))
+	first := acc.Bitmap()
+	first.Set(99)
+	require.True(t, first.Contains(99))
+
+	second := acc.Bitmap()
+	require.Equal(t, []uint64{1, 2, 3}, second.ToArray())
+	require.True(t, first.Contains(99))
+}

--- a/accumulator_test.go
+++ b/accumulator_test.go
@@ -199,6 +199,24 @@ func TestAccumulatorOrSkipsEmptyContainers(t *testing.T) {
 	require.Equal(t, []uint64{1 << 20}, acc.Bitmap().ToArray())
 }
 
+func TestAccumulatorZeroValue(t *testing.T) {
+	var acc Accumulator
+	acc.Or(bitmapOf(1, 100_000))
+	acc.Or(bitmapOf(2))
+	require.Equal(t, []uint64{1, 2, 100_000}, acc.Bitmap().ToArray())
+}
+
+func TestAccumulatorOrUnknownContainerType(t *testing.T) {
+	// FromBuffer adopts arbitrary bytes without validating container type
+	// tags; a tag that is neither array nor bitmap must fail loudly instead
+	// of silently dropping the container's elements from the union.
+	bm := bitmapOf(5)
+	bm.getContainer(bm.keys.val(0))[indexType] = typeBitmap + 1
+
+	acc := NewAccumulator()
+	require.Panics(t, func() { acc.Or(bm) })
+}
+
 func TestAccumulatorReset(t *testing.T) {
 	acc := NewAccumulator()
 	acc.Or(bitmapOf(1, 2, 3))
@@ -287,25 +305,25 @@ func TestAccumulatorBitmapToBuf(t *testing.T) {
 		require.Equal(t, &buf[0], &got._ptr[0])
 	})
 
-	t.Run("too small falls back to heap", func(t *testing.T) {
+	t.Run("too small panics", func(t *testing.T) {
 		acc := build()
-		got := acc.BitmapToBuf(func(int) []byte { return make([]byte, 16) })
-		require.Equal(t, want, got.ToArray())
-		require.Nil(t, got._ptr)
+		require.Panics(t, func() {
+			acc.BitmapToBuf(func(int) []byte { return make([]byte, 16) })
+		})
 	})
 
-	t.Run("one uint16 short falls back to heap", func(t *testing.T) {
+	t.Run("one uint16 short panics leaving the buffer untouched", func(t *testing.T) {
 		// The requested size fits exactly (see "result occupies exactly the
-		// requested size"); one uint16 less must fall back and leave the
-		// buffer untouched.
+		// requested size"); one uint16 less must panic without writing to
+		// the buffer.
 		acc := build()
 		var buf []byte
-		got := acc.BitmapToBuf(func(n int) []byte {
-			buf = make([]byte, n-2)
-			return buf
+		require.Panics(t, func() {
+			acc.BitmapToBuf(func(n int) []byte {
+				buf = make([]byte, n-2)
+				return buf
+			})
 		})
-		require.Equal(t, want, got.ToArray())
-		require.Nil(t, got._ptr)
 		require.Equal(t, make([]byte, len(buf)), buf)
 	})
 
@@ -334,7 +352,7 @@ func TestAccumulatorBitmapToBuf(t *testing.T) {
 	t.Run("result occupies exactly the requested size without key 0", func(t *testing.T) {
 		// A union that never touches key 0 keeps the pre-created key-0
 		// container as a minimum-size placeholder that is still part of the
-		// serialized slab.
+		// serialized bytes.
 		acc := NewAccumulator()
 		for i := 1; i <= 40; i++ {
 			acc.Or(bitmapOf(uint64(i) << 16))
@@ -346,7 +364,7 @@ func TestAccumulatorBitmapToBuf(t *testing.T) {
 	})
 
 	t.Run("dirty buffer does not leak into serialized bytes", func(t *testing.T) {
-		// ToBuffer serializes the whole data slab, so every byte of the
+		// ToBuffer serializes the whole data array, so every byte of the
 		// result — including array-container padding — must be independent
 		// of the buffer's prior contents.
 		serialize := func(fill byte) []byte {
@@ -360,6 +378,70 @@ func TestAccumulatorBitmapToBuf(t *testing.T) {
 			}).ToBufferWithCopy()
 		}
 		require.Equal(t, serialize(0x00), serialize(0xFF))
+	})
+
+	t.Run("dirty buffer does not leak without key 0", func(t *testing.T) {
+		// The key-0 placeholder is the one container the build never
+		// overwrites — its up-front clearing alone must keep serialization
+		// deterministic.
+		serialize := func(fill byte) []byte {
+			acc := NewAccumulator()
+			for i := 1; i <= 40; i++ {
+				acc.Or(bitmapOf(uint64(i)<<16 | uint64(i)))
+			}
+			return acc.BitmapToBuf(func(n int) []byte {
+				buf := make([]byte, n)
+				for i := range buf {
+					buf[i] = fill
+				}
+				return buf
+			}).ToBufferWithCopy()
+		}
+		require.Equal(t, serialize(0x00), serialize(0xFF))
+	})
+
+	t.Run("odd-capacity buffer", func(t *testing.T) {
+		acc := build()
+		var buf []byte
+		got := acc.BitmapToBuf(func(n int) []byte {
+			buf = make([]byte, n, n+1) // odd spare byte the bitmap cannot use
+			return buf
+		})
+		require.Equal(t, want, got.ToArray())
+		require.Equal(t, &buf[0], &got._ptr[0])
+	})
+
+	t.Run("nil buffer panics", func(t *testing.T) {
+		acc := build()
+		require.Panics(t, func() {
+			acc.BitmapToBuf(func(int) []byte { return nil })
+		})
+	})
+
+	t.Run("get using the accumulator panics", func(t *testing.T) {
+		// A deposit inside get would desync the staged bits from the layout
+		// snapshot the build was sized with, silently corrupting the result.
+		acc := NewAccumulator()
+		acc.Or(bitmapOf(100, 200, 300))
+		require.PanicsWithValue(t,
+			"Accumulator: mutated during build — get must not use the accumulator",
+			func() {
+				acc.BitmapToBuf(func(n int) []byte {
+					acc.Or(bitmapOf(1, 2, 3))
+					return make([]byte, n)
+				})
+			})
+	})
+
+	t.Run("get resetting the accumulator panics", func(t *testing.T) {
+		acc := NewAccumulator()
+		acc.Or(bitmapOf(100, 200, 300))
+		require.Panics(t, func() {
+			acc.BitmapToBuf(func(n int) []byte {
+				acc.Reset()
+				return make([]byte, n)
+			})
+		})
 	})
 
 	t.Run("ToBuffer FromBuffer round-trip", func(t *testing.T) {
@@ -419,20 +501,19 @@ func TestAccumulatorInitBitmapToBuf(t *testing.T) {
 		require.Equal(t, &buf[0], &got._ptr[0])
 	})
 
-	t.Run("too small sets the struct to a heap-built union", func(t *testing.T) {
+	t.Run("too small panics", func(t *testing.T) {
 		var bm Bitmap
 		acc := NewAccumulator()
 		acc.Or(a)
-		got := acc.InitBitmapToBuf(func(int) (*Bitmap, []byte) {
-			return &bm, make([]byte, 16)
+		require.Panics(t, func() {
+			acc.InitBitmapToBuf(func(int) (*Bitmap, []byte) {
+				return &bm, make([]byte, 16)
+			})
 		})
-		require.Same(t, &bm, got)
-		require.Equal(t, a.ToArray(), got.ToArray())
-		require.Nil(t, got._ptr)
 	})
 
 	t.Run("dirty buffer serializes deterministically at exact size", func(t *testing.T) {
-		// Same guarantees the BitmapToBuf subtests pin, routed directly
+		// Same guarantees the BitmapToBuf subtests assert, routed directly
 		// through the Init path: byte-deterministic serialization filling
 		// the buffer exactly. The union holds array containers, so padding
 		// tails are exercised.

--- a/accumulator_test.go
+++ b/accumulator_test.go
@@ -186,6 +186,19 @@ func TestAccumulator(t *testing.T) {
 	}
 }
 
+func TestAccumulatorOrSkipsEmptyContainers(t *testing.T) {
+	// Removing every element of a container leaves a zero-cardinality
+	// container inside a non-empty bitmap; Or must skip it rather than
+	// stage its range.
+	bm := bitmapOf(5, 1<<20)
+	bm.Remove(5)
+
+	acc := NewAccumulator()
+	acc.Or(bm)
+	require.Len(t, acc.keys, 1)
+	require.Equal(t, []uint64{1 << 20}, acc.Bitmap().ToArray())
+}
+
 func TestAccumulatorReset(t *testing.T) {
 	acc := NewAccumulator()
 	acc.Or(bitmapOf(1, 2, 3))
@@ -416,6 +429,30 @@ func TestAccumulatorInitBitmapToBuf(t *testing.T) {
 		require.Same(t, &bm, got)
 		require.Equal(t, a.ToArray(), got.ToArray())
 		require.Nil(t, got._ptr)
+	})
+
+	t.Run("dirty buffer serializes deterministically at exact size", func(t *testing.T) {
+		// Same guarantees the BitmapToBuf subtests pin, routed directly
+		// through the Init path: byte-deterministic serialization filling
+		// the buffer exactly. The union holds array containers, so padding
+		// tails are exercised.
+		var size int
+		serialize := func(fill byte) []byte {
+			var bm Bitmap
+			acc := NewAccumulator()
+			acc.Or(a)
+			return acc.InitBitmapToBuf(func(n int) (*Bitmap, []byte) {
+				size = n
+				buf := make([]byte, n)
+				for i := range buf {
+					buf[i] = fill
+				}
+				return &bm, buf
+			}).ToBufferWithCopy()
+		}
+		s0, s1 := serialize(0x00), serialize(0xFF)
+		require.Equal(t, s0, s1)
+		require.Len(t, s0, size)
 	})
 
 	t.Run("warm accumulator with pooled memory allocates nothing", func(t *testing.T) {

--- a/benchmark_accumulator_test.go
+++ b/benchmark_accumulator_test.go
@@ -29,14 +29,10 @@ func BenchmarkOr(b *testing.B) {
 		}
 		return sources
 	}
-	makeLarge := func(rng *rand.Rand, n, card int, universe uint64) []*Bitmap {
+	makeLarge := func(seed int64, n, card int, universe uint64) []*Bitmap {
 		sources := make([]*Bitmap, n)
 		for i := range sources {
-			bm := NewBitmap()
-			for j := 0; j < card; j++ {
-				bm.Set(rng.Uint64() % universe)
-			}
-			sources[i] = bm
+			sources[i] = randomBitmap(seed+int64(i), card, universe)
 		}
 		return sources
 	}
@@ -49,10 +45,13 @@ func BenchmarkOr(b *testing.B) {
 		{"tiny_10k_u300k", makeTiny(rand.New(rand.NewSource(2)), 10_000, 300_000)},
 		{"tiny_100k_u300k", makeTiny(rand.New(rand.NewSource(3)), 100_000, 300_000)},
 		{"tiny_100k_u10m", makeTiny(rand.New(rand.NewSource(4)), 100_000, 10_000_000)},
+		{"tiny_100k_u100m", makeTiny(rand.New(rand.NewSource(8)), 100_000, 100_000_000)},
+		{"tiny_100k_u300m", makeTiny(rand.New(rand.NewSource(9)), 100_000, 300_000_000)},
+		{"tiny_100k_u1b", makeTiny(rand.New(rand.NewSource(10)), 100_000, 1_000_000_000)},
 		{"mixed_10k_tiny_5_large_u10m", append(
 			makeTiny(rand.New(rand.NewSource(5)), 10_000, 10_000_000),
-			makeLarge(rand.New(rand.NewSource(6)), 5, 200_000, 10_000_000)...)},
-		{"large_8x1m_u10m", makeLarge(rand.New(rand.NewSource(7)), 8, 1_000_000, 10_000_000)},
+			makeLarge(6, 5, 200_000, 10_000_000)...)},
+		{"large_8x1m_u10m", makeLarge(7, 8, 1_000_000, 10_000_000)},
 	}
 
 	strategies := []struct {

--- a/benchmark_accumulator_test.go
+++ b/benchmark_accumulator_test.go
@@ -1,0 +1,114 @@
+package sroar
+
+import (
+	"math/rand"
+	"sort"
+	"testing"
+)
+
+// Benchmarks comparing N-way union strategies across different source shapes:
+//
+//   - tiny sources (cardinality 1) — many singleton bitmaps, the shape that
+//     makes pairwise merge slow
+//   - mixed (tiny sources plus a few large ones)
+//   - few large sources
+//
+// Strategies:
+//
+//   - IterOr:     acc.Or(src) one source at a time
+//   - FastOr:     sroar's variadic two-pass union
+//   - SortedList: extract all elements, sort, dedup, FromSortedList
+//   - Accumulator: dense staging
+func BenchmarkOr(b *testing.B) {
+	makeTiny := func(rng *rand.Rand, n int, universe uint64) []*Bitmap {
+		sources := make([]*Bitmap, n)
+		for i := range sources {
+			bm := NewBitmap()
+			bm.Set(rng.Uint64() % universe)
+			sources[i] = bm
+		}
+		return sources
+	}
+	makeLarge := func(rng *rand.Rand, n, card int, universe uint64) []*Bitmap {
+		sources := make([]*Bitmap, n)
+		for i := range sources {
+			bm := NewBitmap()
+			for j := 0; j < card; j++ {
+				bm.Set(rng.Uint64() % universe)
+			}
+			sources[i] = bm
+		}
+		return sources
+	}
+
+	fixtures := []struct {
+		name    string
+		sources []*Bitmap
+	}{
+		{"tiny_1k_u300k", makeTiny(rand.New(rand.NewSource(1)), 1_000, 300_000)},
+		{"tiny_10k_u300k", makeTiny(rand.New(rand.NewSource(2)), 10_000, 300_000)},
+		{"tiny_100k_u300k", makeTiny(rand.New(rand.NewSource(3)), 100_000, 300_000)},
+		{"tiny_100k_u10m", makeTiny(rand.New(rand.NewSource(4)), 100_000, 10_000_000)},
+		{"mixed_10k_tiny_5_large_u10m", append(
+			makeTiny(rand.New(rand.NewSource(5)), 10_000, 10_000_000),
+			makeLarge(rand.New(rand.NewSource(6)), 5, 200_000, 10_000_000)...)},
+		{"large_8x1m_u10m", makeLarge(rand.New(rand.NewSource(7)), 8, 1_000_000, 10_000_000)},
+	}
+
+	strategies := []struct {
+		name  string
+		union func(sources []*Bitmap) *Bitmap
+	}{
+		{"IterOr", func(sources []*Bitmap) *Bitmap {
+			acc := NewBitmap()
+			for _, s := range sources {
+				acc.Or(s)
+			}
+			return acc
+		}},
+		{"FastOr", func(sources []*Bitmap) *Bitmap {
+			return FastOr(sources...)
+		}},
+		{"SortedList", func(sources []*Bitmap) *Bitmap {
+			var vals []uint64
+			for _, s := range sources {
+				vals = append(vals, s.ToArray()...)
+			}
+			sort.Slice(vals, func(i, j int) bool { return vals[i] < vals[j] })
+			// Dedup in place; FromSortedList requires strictly deduped input.
+			n := 0
+			for i, v := range vals {
+				if i == 0 || v != vals[n-1] {
+					vals[n] = v
+					n++
+				}
+			}
+			return FromSortedList(vals[:n])
+		}},
+		{"Accumulator", func(sources []*Bitmap) *Bitmap {
+			acc := NewAccumulator()
+			for _, s := range sources {
+				acc.Or(s)
+			}
+			return acc.Bitmap()
+		}},
+	}
+
+	for _, fx := range fixtures {
+		// Sanity: all strategies must agree before their numbers mean anything.
+		want := strategies[0].union(fx.sources).GetCardinality()
+		for _, st := range strategies[1:] {
+			if got := st.union(fx.sources).GetCardinality(); got != want {
+				b.Fatalf("%s/%s: cardinality %d, want %d", fx.name, st.name, got, want)
+			}
+		}
+		for _, st := range strategies {
+			b.Run(fx.name+"/"+st.name, func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					_ = st.union(fx.sources)
+				}
+			})
+		}
+	}
+}

--- a/bitmap.go
+++ b/bitmap.go
@@ -472,30 +472,20 @@ func FromSortedList(vals []uint64) *Bitmap {
 		if len(l) == 0 {
 			return
 		}
-		if len(l) <= 2048 {
-			// 4 uint16s for the header, and extra 4 uint16s so that adding more elements using
-			// Set operation doesn't fail.
-			sz := uint16(8 + len(l))
-			off = ra.newContainer(sz)
-			c := ra.getContainer(off)
-			c[indexSize] = sz
-			c[indexType] = typeArray
+		sz, typ := containerSizeForCard(len(l))
+		off = ra.newContainer(sz)
+		c := ra.getContainer(off)
+		c[indexSize] = sz
+		c[indexType] = typ
+		if typ == typeArray {
 			setCardinality(c, len(l))
-			for i := 0; i < len(l); i++ {
-				c[int(startIdx)+i] = l[i]
-			}
-
+			copy(c[startIdx:], l)
 		} else {
-			off = ra.newContainer(maxContainerSize)
-			c := ra.getContainer(off)
-			c[indexSize] = maxContainerSize
-			c[indexType] = typeBitmap
 			for _, v := range l {
 				bitmap(c).add(v)
 			}
 		}
 		ra.setKey(key, off)
-		return
 	}
 
 	lastHi = 0

--- a/bitmap_opt.go
+++ b/bitmap_opt.go
@@ -264,6 +264,18 @@ func compactedArraySize(n int) int {
 	return min((int(startIdx)+n+1+3)&^3, maxContainerSize)
 }
 
+// containerSizeForCard returns the size and type of the container that
+// materializes cardinality n within one key range: a compacted array up to
+// 2048 values, a bitmap container above. Shared by the exact-size
+// constructors (FromSortedList, Accumulator) so identical content gets
+// identical container layout regardless of which built it.
+func containerSizeForCard(n int) (sz uint16, typ uint16) {
+	if n <= 2048 {
+		return uint16(compactedArraySize(n)), typeArray
+	}
+	return maxContainerSize, typeBitmap
+}
+
 // andNotResultSize returns the uint16s the result for source ac occupies in
 // res at cardinality n. A bitmap source at/above the threshold stays a
 // maxContainerSize bitmap, so andNotResultCard's clamp there is harmless.

--- a/bitmap_test.go
+++ b/bitmap_test.go
@@ -525,6 +525,52 @@ func TestSetSorted(t *testing.T) {
 	check(1e6)
 }
 
+func TestFromSortedListContainerAlignment(t *testing.T) {
+	// Container payloads are read through uint64 views
+	// (uint16To64SliceUnsafe), so every container must start 8-byte
+	// aligned. containerSizeForCard keeps sizes at multiples of 4 uint16s
+	// even for small array containers, so no container can misalign the
+	// ones that follow it.
+	bm := FromSortedList([]uint64{1, 2, 3, 1 << 20, 1<<20 + 1, 1 << 40})
+	n := bm.keys.numKeys()
+	require.Equal(t, 3, n)
+	for i := 0; i < n; i++ {
+		require.Zero(t, bm.keys.val(i)%4)
+	}
+}
+
+func TestSetIntoCompactedArrayContainer(t *testing.T) {
+	// containerSizeForCard can leave a single spare slot in a fresh array
+	// container (e.g. cardinality 2047, vs the old sizing's fixed 4);
+	// growing past the spares and across the 2048 array-bitmap cutoff
+	// must work for containers built by both exact-size constructors.
+	for _, n := range []int{2046, 2047, 2048} {
+		vals := make([]uint64, n)
+		for i := range vals {
+			vals[i] = uint64(i) * 2 // even values: odd ones stay free to Set
+		}
+		builders := map[string]func() *Bitmap{
+			"FromSortedList": func() *Bitmap { return FromSortedList(vals) },
+			"Accumulator": func() *Bitmap {
+				acc := NewAccumulator()
+				acc.Or(bitmapOf(vals...))
+				return acc.Bitmap()
+			},
+		}
+		for name, build := range builders {
+			t.Run(fmt.Sprintf("%s n=%d", name, n), func(t *testing.T) {
+				bm := build()
+				for j := 0; j < 5; j++ {
+					v := uint64(j)*2 + 1
+					require.True(t, bm.Set(v))
+					require.True(t, bm.Contains(v))
+				}
+				require.Equal(t, n+5, bm.GetCardinality())
+			})
+		}
+	}
+}
+
 // testMaskedCommon runs the shared correctness cases for Masked and MaskedToBuf.
 // masker abstracts the call so each test function can pass its own implementation.
 func testMaskedCommon(t *testing.T, masker func(bm *Bitmap, mask uint64) *Bitmap) {

--- a/bitmap_test.go
+++ b/bitmap_test.go
@@ -540,10 +540,10 @@ func TestFromSortedListContainerAlignment(t *testing.T) {
 }
 
 func TestSetIntoCompactedArrayContainer(t *testing.T) {
-	// containerSizeForCard can leave a single spare slot in a fresh array
-	// container (e.g. cardinality 2047, vs the old sizing's fixed 4);
-	// growing past the spares and across the 2048 array-bitmap cutoff
-	// must work for containers built by both exact-size constructors.
+	// containerSizeForCard can leave as little as one spare slot in a fresh
+	// array container (e.g. cardinality 2047); growing past the spares and
+	// across the 2048 array-bitmap cutoff must work for containers built by
+	// both exact-size constructors.
 	for _, n := range []int{2046, 2047, 2048} {
 		vals := make([]uint64, n)
 		for i := range vals {

--- a/container.go
+++ b/container.go
@@ -596,14 +596,23 @@ func (b bitmap) all() []uint16 {
 // number written. Stops when out is full, so a cardinality header that
 // understates the popcount degrades deterministically rather than overrunning.
 func (b bitmap) intoArray(out []uint16) int {
+	return bitsIntoArray(b[startIdx:], out)
+}
+
+// bitsIntoArray writes the set values of a headerless run of bitmap words (a
+// bitmap container's data past its header, or an Accumulator staging block)
+// into out in ascending order and returns the number written. Stops when out
+// is full, so an out sized below the words' popcount degrades
+// deterministically rather than overrunning.
+func bitsIntoArray(words []uint16, out []uint16) int {
 	idx := 0
-	for w, word := range b[startIdx:] {
+	for w, word := range words {
 		if word == 0 {
 			continue
 		}
 		base := uint16(w) << 4
-		// bitmapMask[pos] is 1<<(15-pos), so the smallest pos is the highest bit:
-		// LeadingZeros16 yields values in ascending order.
+		// bitmapMask[pos] is 1<<(15-pos), so the smallest pos is the highest
+		// bit: LeadingZeros16 yields values in ascending order.
 		for word != 0 {
 			if idx == len(out) {
 				return idx


### PR DESCRIPTION
## Motivation

Unioning N tiny bitmaps with `Or`/`FastOr` pays a structural container merge per source — for array containers an O(container size) memmove to insert even a single element — making N-way unions of near-singleton bitmaps quadratic in the source count.

## Approach

`Accumulator` skips pairwise merging: each touched 64K key range gets one fixed 8KB dense staging block, sources deposit bits directly (bit-sets for array containers, word-ORs for bitmap containers), so every deposit is O(1). A popcount pass then fixes the complete result layout and `buildInto` writes each container exactly once into an exactly-sized allocation. Total cost: O(total elements + touched ranges); staging memory tracks the result's doc-ID spread, not the source count.

Built for pooling: `Or` never retains its argument; `BitmapToBuf`/`InitBitmapToBuf` build into caller memory via a callback invoked once with the exact size (`InitBitmapToBuf` also takes the result struct from the pool, so a warm accumulator allocates nothing — gated by an `AllocsPerRun` test); `Reset` bounds retained spares at 16 blocks.

Supporting changes: `FromSortedList` shares the container-size rule via `containerSizeForCard`; `newBitampToBuf` typo fixed and split into a thin wrapper over in-place `initBitmapToBuf`; `bitmap.intoArray` delegates to the shared `bitsIntoArray`.

Design rationale in the type docs ([accumulator.go#L5](https://github.com/weaviate/sroar/blob/9382b19/accumulator.go#L5)).

## Key areas for review

- `buildInto` — the no-reallocation invariant: `setKey`'s return is discarded, safe only because the keys node carries one spare slot (`newKeys+2`) and containers are appended in ascending key order ([accumulator.go#L240](https://github.com/weaviate/sroar/blob/9382b19/accumulator.go#L240)).
- `layout`/`buildInto` — the key-0 container is pre-created by construction, so it is sized exactly (`sizeInitial`) and filled in place instead of appended.
- `InitBitmapToBuf` — dirty pooled buffers: every exposed byte is written or explicitly cleared, so serialization is byte-deterministic; a too-small buffer is left untouched (heap fallback).

## Risks

- `FromSortedList` array containers are now compacted-4-aligned instead of `8+len`, so serialized bytes differ across versions for identical content. Reads are unaffected (container sizes are self-describing); round-trips are tested. No known consumer byte-compares or hashes serialized bitmaps.

## Testing

Table-driven correctness across source shapes (nil/empty, singletons, spread/mixed universes, key-0 and top key ranges, the 2048 array/bitmap cutoff, full container) against a reference union; pooled-path tests (dirty-buffer determinism, exact occupancy, fallback boundaries incl. one-uint16-short, round-trip, struct/buffer reuse, zero-alloc gate). Benchmarks vs `IterOr`/`FastOr`/sort+`FromSortedList`: 9–34x on 1K–100K card-1 sources, 4x mixed, parity on few-large-sources.
