### PR TITLE
perf(container): count cardinality 64 bits at a time, and benchmark the range cascade

### DIFF
--- a/benchmark_range_cascade_test.go
+++ b/benchmark_range_cascade_test.go
@@ -1,0 +1,210 @@
+package sroar
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"testing"
+)
+
+// Models the merge cascade a bit-sliced numeric range filter drives, at
+// production shape. Timing includes GetCardinality so any deferred header
+// cost lands in the result. Uses only released APIs, so it also runs as a
+// baseline on old checkouts.
+
+// cascadeShape describes the production-shaped operand set: 369 bitmap
+// containers per plane at ~24.2M values, matching a single shard's range planes.
+type cascadeShape struct {
+	containers int
+	planes     int
+	// densityBits: fill is 1 - 2^-densityBits, high enough to keep containers
+	// non-empty/non-full bitmaps so every pass does real work.
+	densityBits int
+}
+
+var productionCascade = cascadeShape{containers: 369, planes: 15, densityBits: 4}
+
+// buildDensePlanes writes containers directly; Set would need 24M calls per plane.
+func buildDensePlanes(shape cascadeShape, seed int64) []*Bitmap {
+	rnd := rand.New(rand.NewSource(seed))
+	planes := make([]*Bitmap, shape.planes)
+	for p := range planes {
+		bm := NewBitmapWith(shape.containers + 2)
+		for k := 0; k < shape.containers; k++ {
+			offset := bm.newContainer(uint16(maxContainerSize))
+			c := bm.getContainer(offset)
+			c[indexSize] = uint16(maxContainerSize)
+			c[indexType] = typeBitmap
+			words := uint16To64SliceUnsafe(c[startIdx:])
+			for i := range words {
+				w := ^uint64(0)
+				for d := 0; d < shape.densityBits; d++ {
+					w &= rnd.Uint64()
+				}
+				words[i] = ^w
+			}
+			calculateAndSetCardinality(c)
+			bm.setKey(uint64(k)<<16, offset)
+		}
+		planes[p] = bm
+	}
+	return planes
+}
+
+// cascadeOps alternates And/Or so density stays bounded and no pass
+// short-circuits on empty or full, keeping both arms doing real work.
+func cascadeOps(n int) []bool {
+	ops := make([]bool, n)
+	for i := range ops {
+		ops[i] = i%2 == 0
+	}
+	return ops
+}
+
+// runCascade times the merge plus reads calls to GetCardinality; that cost
+// is lazy, so it lands only on callers who ask.
+func runCascade(b *testing.B, planes []*Bitmap, workers, reads int) {
+	ops := cascadeOps(len(planes) - 1)
+	buf := make([]byte, planes[0].LenInBytes()*2)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink int
+	for i := 0; i < b.N; i++ {
+		merged := planes[0].CloneToBuf(buf)
+		for j, isAnd := range ops {
+			if isAnd {
+				merged.AndConc(planes[j+1], workers)
+			} else {
+				merged.OrConc(planes[j+1], workers)
+			}
+		}
+		sink += merged.NumContainers()
+		for r := 0; r < reads; r++ {
+			sink += merged.GetCardinality()
+		}
+	}
+	b.StopTimer()
+	if sink == 0 {
+		b.Fatal("cascade produced an empty result; the shape is wrong")
+	}
+}
+
+// BenchmarkRangeCascade sweeps merge workers and cardinality reads: merges
+// parallelize across workers, but per-container cardinality work does not.
+func BenchmarkRangeCascade(b *testing.B) {
+	planes := buildDensePlanes(productionCascade, 1)
+	for _, workers := range []int{1, 4, 8} {
+		for _, reads := range []int{0, 1, 3} {
+			b.Run(fmt.Sprintf("workers=%d/reads=%d", workers, reads), func(b *testing.B) {
+				runCascade(b, planes, workers, reads)
+			})
+		}
+	}
+}
+
+// BenchmarkCorpusMerge replays the merge over real corpus data in
+// testdata/bitmaps, for a realistic container mix and density. Skips if the
+// corpus isn't checked out.
+func BenchmarkCorpusMerge(b *testing.B) {
+	for _, dataset := range corpusDatasets() {
+		pairs := loadCorpusPairs(b, dataset)
+		if len(pairs) < 2 {
+			continue
+		}
+		for _, workers := range []int{1, 4, 8} {
+			b.Run(fmt.Sprintf("%s/workers=%d", dataset, workers), func(b *testing.B) {
+				buf := make([]byte, pairs[0].additions.LenInBytes()*4)
+				b.ReportAllocs()
+				b.ResetTimer()
+				var sink int
+				for i := 0; i < b.N; i++ {
+					merged := pairs[0].additions.CloneToBuf(buf)
+					for j := 1; j < len(pairs); j++ {
+						if pairs[j].deletions != nil {
+							merged.AndNotConc(pairs[j].deletions, workers)
+						}
+						if pairs[j].additions != nil {
+							merged.OrConc(pairs[j].additions, workers)
+						}
+					}
+					sink += merged.GetCardinality()
+				}
+				b.StopTimer()
+				if sink == 0 {
+					b.Fatal("merge produced an empty result")
+				}
+			})
+		}
+	}
+}
+
+func corpusDatasets() []string {
+	entries, err := os.ReadDir(filepath.Join("testdata", "bitmaps"))
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() {
+			out = append(out, e.Name())
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+type corpusPair struct {
+	additions *Bitmap
+	deletions *Bitmap
+}
+
+func loadCorpusPairs(b *testing.B, dataset string) []corpusPair {
+	dir := filepath.Join("testdata", "bitmaps", dataset)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		b.Skipf("corpus %q not checked out: %v", dataset, err)
+	}
+	re := regexp.MustCompile(`^(\d+)_(additions|deletions)\.bm$`)
+
+	byID := map[string]*corpusPair{}
+	var ids []string
+	for _, e := range entries {
+		m := re.FindStringSubmatch(e.Name())
+		if m == nil {
+			continue
+		}
+		p, ok := byID[m[1]]
+		if !ok {
+			p = &corpusPair{}
+			byID[m[1]] = p
+			ids = append(ids, m[1])
+		}
+		content, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			b.Fatalf("read %s: %v", e.Name(), err)
+		}
+		bm := FromBuffer(content)
+		if bm.IsEmpty() {
+			continue
+		}
+		if m[2] == "additions" {
+			p.additions = bm
+		} else {
+			p.deletions = bm
+		}
+	}
+	sort.Strings(ids)
+
+	var out []corpusPair
+	for _, id := range ids {
+		out = append(out, *byID[id])
+	}
+	if len(out) == 0 || out[0].additions == nil {
+		b.Skipf("corpus %q has no seed additions", dataset)
+	}
+	return out
+}

--- a/container.go
+++ b/container.go
@@ -747,7 +747,16 @@ func (b bitmap) maximum() uint16 {
 
 func (b bitmap) cardinality() int {
 	var num int
-	for _, x := range b[startIdx:] {
+	data := b[startIdx:]
+	// Popcount64 costs the same as popcount16, so batching 4x fewer
+	// instructions is free. Fall back for slices not a multiple of 4.
+	if len(data)%4 == 0 {
+		for _, w := range uint16To64SliceUnsafe(data) {
+			num += bits.OnesCount64(w)
+		}
+		return num
+	}
+	for _, x := range data {
 		num += bits.OnesCount16(x)
 	}
 	return num

--- a/container_cardinality_test.go
+++ b/container_cardinality_test.go
@@ -1,0 +1,93 @@
+package sroar
+
+import (
+	"math/bits"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// cardinalityNarrow is the oracle bitmap.cardinality is checked against.
+func cardinalityNarrow(b bitmap) int {
+	var num int
+	for _, x := range b[startIdx:] {
+		num += bits.OnesCount16(x)
+	}
+	return num
+}
+
+func TestBitmapCardinalityWidthAgrees(t *testing.T) {
+	newContainer := func(fill func(words []uint64)) bitmap {
+		c := make([]uint16, maxContainerSize)
+		c[indexSize] = uint16(maxContainerSize)
+		c[indexType] = typeBitmap
+		fill(uint16To64SliceUnsafe(c[startIdx:]))
+		return bitmap(c)
+	}
+
+	rnd := rand.New(rand.NewSource(5))
+	cases := []struct {
+		name string
+		fill func(words []uint64)
+	}{
+		{"all zero", func(words []uint64) {}},
+		{"all ones", func(words []uint64) {
+			for i := range words {
+				words[i] = ^uint64(0)
+			}
+		}},
+		{"single bit in first word", func(words []uint64) { words[0] = 1 }},
+		{"single bit in last word", func(words []uint64) { words[len(words)-1] = 1 << 63 }},
+		{"alternating words", func(words []uint64) {
+			for i := range words {
+				if i%2 == 0 {
+					words[i] = ^uint64(0)
+				}
+			}
+		}},
+		{"alternating bits", func(words []uint64) {
+			for i := range words {
+				words[i] = 0xAAAAAAAAAAAAAAAA
+			}
+		}},
+		{"random dense", func(words []uint64) {
+			for i := range words {
+				words[i] = ^(rnd.Uint64() & rnd.Uint64())
+			}
+		}},
+		{"random sparse", func(words []uint64) {
+			for i := range words {
+				words[i] = rnd.Uint64() & rnd.Uint64() & rnd.Uint64() & rnd.Uint64()
+			}
+		}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			b := newContainer(c.fill)
+			require.Equal(t, cardinalityNarrow(b), b.cardinality())
+		})
+	}
+
+	t.Run("full container reports maxCardinality", func(t *testing.T) {
+		b := newContainer(func(words []uint64) {
+			for i := range words {
+				words[i] = ^uint64(0)
+			}
+		})
+		require.Equal(t, maxCardinality, b.cardinality())
+	})
+
+	// Pins the narrow-loop fallback for slice lengths not a multiple of 4.
+	t.Run("data length not a multiple of four", func(t *testing.T) {
+		c := make([]uint16, int(startIdx)+6)
+		c[indexType] = typeBitmap
+		c[indexSize] = uint16(len(c))
+		c[startIdx] = 0xFFFF
+		c[startIdx+3] = 0x00FF
+		c[startIdx+5] = 0x0001
+		require.Equal(t, 16+8+1, bitmap(c).cardinality())
+		require.Equal(t, cardinalityNarrow(bitmap(c)), bitmap(c).cardinality())
+	})
+}


### PR DESCRIPTION
SuperClaude here.

## What this is

This started as an attempt to restore lazy cardinality to the `*Alt` merge path. The machinery for it still exists (`runLazy` at `container.go:763`, `invalidCardinality` at `:61`, `calculateAndSetCardinality` at `:108`, and a working consumer in `FastOr`), the legacy path still honours it (`container.go:507`, `:559`), and `grep -c runLazy container_opt.go` returns `0` — so the `*Alt` rewrite simply dropped it. The theory was that a bit-sliced numeric range filter runs ~14 whole-bitmap passes and 13 of them compute a per-container cardinality that the next pass immediately overwrites.

**I implemented it, measured it against shipped code, and it is a regression at production concurrency.** So this PR ships only the two things that measured clean: one unconditional fix and the benchmark that produced the result. The full implementation is pushed to `perf-lazy-cardinality-alt-ops` so the measurement can be reproduced or challenged; it is not proposed for merge.

## What is in the diff

**1. `bitmap.cardinality()` counts 64 bits at a time.** It counted one `uint16` at a time. A popcount instruction costs the same at either width, so the narrow loop issued four per word for no extra information. **4.24× on a 369-container sweep** (1,561,698 → 368,744 ns, Neoverse N1, min-of-5, cv < 0.2%).

Scope, stated plainly: the only caller is `calculateAndSetCardinality`, whose only caller is `FastOr`. That speeds up `FastOr`'s header-settling loop and nothing else. It is real for this library; it does not touch a filtered-query path in weaviate, which does not call `FastOr`.

**2. A benchmark for the merge a range filter drives.** 369 bitmap containers per plane at ~24.2M values, 14 alternating `AndConc`/`OrConc` passes — the shape a single shard's range planes have. Swept over two axes:

- **merge workers** (1, 4, 8), because the merge fans out;
- **how many times the caller reads the result's cardinality** (0, 1, 3), because per-container cardinality work does not fan out.

The second axis is the one that decided this investigation, and it is not obvious from reading the code that it matters. `BenchmarkCorpusMerge` replays the same operators over the recorded bitmaps under `testdata/bitmaps` when that corpus is checked out (it skips otherwise).

## The measurement that killed the optimisation

Neoverse N1 (`t2a-standard-8`, Ampere Altra), `GOMAXPROCS=8`, min-of-7, both arms built from the same benchmark file, baseline is this branch's merge base and not a reconstruction.

| merge workers | reads=0 | reads=1 | reads=3 |
|---|---:|---:|---:|
| 1 | 1.125× | 1.071× | 0.976× |
| 4 | 1.066× | 0.959× | 0.776× |
| 8 | 1.033× | **0.859×** | **0.695×** |

Deferring the popcount does speed the merge up — but only by 1.03–1.13×, and the whole gain is handed back the first time anyone asks for a cardinality. Settling the deferred headers costs about three quarters of a full OR pass and is serial, while the 13 saved popcounts are spread across the merge workers. So the win shrinks with worker count while the cost does not, and the two cross over between 1 and 4 workers.

Why 1.03–1.13× and not more, from a word-loop microbenchmark over the same 2.95 MiB working set (min-of-5):

| variant | ns/op | vs exact |
|---|---:|---:|
| OR + exact popcount (shipped) | 527,149 | 1.000× |
| OR + deferred, two accumulators (keeps empty **and** full exact) | 469,133 | 1.124× |
| OR + deferred, one accumulator (keeps empty exact only) | 413,713 | 1.274× |
| OR with no cardinality accounting at all | 353,988 | 1.489× |
| settle sweep (popcount only, no store) | 395,227 | — |

The popcount is 33% of an OR pass at most. Keeping empty **and** full exact — which is not optional, see below — captures 1.124× of that. A cascade of 14 such passes therefore cannot exceed ~1.12× before any settling cost, and the measured 1.125× at `workers=1/reads=0` matches that ceiling exactly. There is no implementation left on the table.

## The correctness constraint, for anyone who revisits this

"Nobody reads the intermediate cardinality" is wrong, and it is worth writing down because it is the trap. The very next operation reads it for `bnum == 0` (`container_opt.go:313`), `bnum == maxCardinality` (`:775`), and the sparse/dense dispatch (`:345`). At the densities a range cascade produces, the full-container OR skip carries real weight.

Two flag accumulators (`orAcc |= w`, `andAcc &= w`) keep empty and full exact for 1–2 ALU ops per word, and the table above prices them: the second accumulator, the one that detects a full container, costs 13% of the pass on its own. Dropping it to buy that 13% back trades away the skip.

## What a reviewer should look at hardest

- **`len(data)%4 == 0` in `cardinality()`.** Bitmap containers are always a whole number of `uint64`s, so the wide loop always runs in practice; the narrow loop is a guard for any caller handing over a shorter slice. `TestBitmapCardinalityWidthAgrees` pins both against the previous implementation across all-zero, all-ones, single-bit-at-either-end, alternating-word, alternating-bit, dense and sparse containers, plus a deliberately non-multiple-of-four slice. `uint16To64SliceUnsafe` needs 8-byte alignment, which is what the surrounding code already relies on.
- **Whether the benchmark's synthetic planes are a fair stand-in.** They are generated to a measured production shape (369 containers, ~2.88 MiB per plane, 14 passes that touch a non-empty layer) rather than sampled, and the density is chosen so no pass is skipped by an empty or full short-circuit — otherwise two arms would silently do different amounts of work. `BenchmarkCorpusMerge` exists as the real-operand cross-check; it is not a nested plane set, because the recorded per-segment additions are disjoint and an AND across them is empty.

## Rebasing

`weaviate/sroar#43` (stacked on `weaviate/sroar#41` and `weaviate/sroar#42`) rewrites the same `container_opt.go` bodies. This PR does not touch `container_opt.go` at all — it changes `bitmap.cardinality()` in `container.go` and adds two test files — so there is no conflict with that stack in either direction, and no rebase ordering to negotiate. The dropped implementation on `perf-lazy-cardinality-alt-ops` *does* touch those bodies and would have needed to land after `#41`+`#42`+`#43`; that is now moot.

## Provenance

The shape being modelled comes from a load test of a large production deployment on `linux/arm64` (Graviton2 class), where this merge is the dominant cost of filtered query serving. All numbers here are from an Ampere Altra box of the same microarchitecture class, against shipped code, min-of-N with N stated.

— SuperClaude
