### PR TITLE
FromSortedList: exact-size single-allocation build, dedup, ToBuf variants

### DIFF
--- a/accumulator.go
+++ b/accumulator.go
@@ -1,7 +1,6 @@
 package sroar
 
 import (
-	"fmt"
 	"math/bits"
 	"slices"
 )
@@ -230,24 +229,7 @@ func (acc *Accumulator) InitBitmapToBuf(get func(sizeBytes int) (*Bitmap, []byte
 	if acc.gen != gen {
 		panic("Accumulator: mutated during build — get must not use the accumulator")
 	}
-	// Same even-capacity view as NewBitmapToBuf: the bitmap operates on
-	// []uint16 (2 bytes per element).
-	buf = buf[:cap(buf)/2*2]
-	if len(buf)/2 < need {
-		// Report cap: it matches what the caller passed, and with need*2
-		// always even the rounded-down len could only confuse.
-		panic(fmt.Sprintf("Accumulator.InitBitmapToBuf: buf too small: need %d bytes, got %d", need*2, cap(buf)))
-	}
-	bufU16 := byteToUint16SliceUnsafe(buf)
-
-	// Pooled buffers arrive dirty. The build writes every byte the result
-	// exposes — container headers and payloads in full, array-container
-	// padding cleared in buildInto — except the keys node's unused slots,
-	// which are cleared here so the serialized form stays deterministic.
-	clear(bufU16[:keysLen])
-
-	initBitmapCore(dst, keysLen, sizeInitial, bufU16)
-	dst._ptr = buf // Keep a GC reference to buf, mirroring NewBitmapToBuf.
+	initBitmapToBufExact("Accumulator.InitBitmapToBuf", dst, buf, keysLen, sizeInitial, need)
 	acc.buildInto(dst, cards)
 	return dst
 }

--- a/accumulator.go
+++ b/accumulator.go
@@ -143,19 +143,21 @@ const layoutScratchLen = 64
 
 // layout runs the popcount pass over the staging blocks, determining the
 // result's complete layout — per-block cardinalities and the derived key
-// and container space needs — so builds can allocate fully sized up front
-// and never reallocate or move anything. cards is scratch[:len(blocks)]
-// when it fits, a fresh slice otherwise. sizeInitial is the pre-created
-// key-0 container's size — exact when the union touches key 0, a
-// minContainerSize placeholder otherwise; sizeContainers covers all
-// remaining containers.
-func (acc *Accumulator) layout(scratch []int) (cards []int, newKeys, sizeInitial, sizeContainers int) {
+// count and container space needs — so builds can allocate fully sized up
+// front and never reallocate or move anything. cards is
+// scratch[:len(blocks)] when it fits, a fresh slice otherwise. numKeys
+// counts the always-present key-0 slot up front; sizeContainer0 is the
+// pre-created key-0 container's size — exact when the union touches key
+// 0, a minContainerSize placeholder otherwise; sizeOtherContainers covers
+// all remaining containers.
+func (acc *Accumulator) layout(scratch []int) (cards []int, numKeys, sizeContainer0, sizeOtherContainers int) {
 	if len(acc.blocks) <= len(scratch) {
 		cards = scratch[:len(acc.blocks)]
 	} else {
 		cards = make([]int, len(acc.blocks))
 	}
-	sizeInitial = minContainerSize
+	numKeys = 1 // the key-0 slot every bitmap pre-creates
+	sizeContainer0 = minContainerSize
 	for i, b := range acc.blocks {
 		card := 0
 		for _, w := range uint16To64SliceUnsafe(b) {
@@ -167,26 +169,27 @@ func (acc *Accumulator) layout(scratch []int) (cards []int, newKeys, sizeInitial
 		}
 		sz, _ := containerSizeForCard(card)
 		if acc.keys[i] != 0 {
-			newKeys++
-			sizeContainers += int(sz)
+			numKeys++
+			sizeOtherContainers += int(sz)
 		} else {
 			// Key 0 is special-cased: every fresh bitmap pre-creates its
 			// key-0 slot and container (the node cannot tell a zero key
-			// from an empty slot), so instead of counting a new key and
-			// appending a duplicate container, the pre-created one is made
-			// exactly this size and filled in place by buildInto.
-			sizeInitial = int(sz)
+			// from an empty slot), so its slot is already counted and,
+			// instead of appending a duplicate container, the pre-created
+			// one is made exactly this size and filled in place by
+			// buildInto.
+			sizeContainer0 = int(sz)
 		}
 	}
-	return cards, newKeys, sizeInitial, sizeContainers
+	return cards, numKeys, sizeContainer0, sizeOtherContainers
 }
 
 // Bitmap assembles and returns the union. The accumulator keeps its staging
 // state afterwards; call Reset to reuse it for a new union.
 func (acc *Accumulator) Bitmap() *Bitmap {
 	var scratch [layoutScratchLen]int
-	cards, newKeys, sizeInitial, sizeContainers := acc.layout(scratch[:])
-	ra := initBitmapWithCap(&Bitmap{}, newKeys+2, sizeInitial, sizeContainers)
+	cards, numKeys, sizeContainer0, sizeOtherContainers := acc.layout(scratch[:])
+	ra := initBitmapWithCap(&Bitmap{}, numKeys+1, sizeContainer0, sizeOtherContainers)
 	acc.buildInto(ra, cards)
 	return ra
 }
@@ -218,25 +221,24 @@ func (acc *Accumulator) BitmapToBuf(get func(sizeBytes int) []byte) *Bitmap {
 // size panics, as in BitmapToBuf.
 func (acc *Accumulator) InitBitmapToBuf(get func(sizeBytes int) (*Bitmap, []byte)) *Bitmap {
 	var scratch [layoutScratchLen]int
-	cards, newKeys, sizeInitial, sizeContainers := acc.layout(scratch[:])
-	// The +2 keys are the always-present key 0 and the spare buildInto
-	// relies on.
-	keysLen := calcInitialKeysLen(newKeys + 2)
-	need := keysLen + sizeInitial + sizeContainers
+	cards, numKeys, sizeContainer0, sizeOtherContainers := acc.layout(scratch[:])
+	// +1 is the spare slot buildInto relies on.
+	sizeKeys := calcSizeKeys(numKeys + 1)
+	sizeTotal := sizeKeys + sizeContainer0 + sizeOtherContainers
 
 	gen := acc.gen
-	dst, buf := get(need * 2)
+	dst, buf := get(sizeTotal * 2)
 	if acc.gen != gen {
 		panic("Accumulator: mutated during build — get must not use the accumulator")
 	}
-	initBitmapToBufExact("Accumulator.InitBitmapToBuf", dst, buf, keysLen, sizeInitial, need)
+	initBitmapToBufExact("Accumulator.InitBitmapToBuf", dst, buf, sizeKeys, sizeContainer0, sizeTotal)
 	acc.buildInto(dst, cards)
 	return dst
 }
 
 // buildInto builds the result containers into ra, whose data array must
 // already have capacity for the full layout and whose keys node must be
-// sized with one spare slot beyond the result's keys (the newKeys+2 at the
+// sized with one spare slot beyond the result's keys (the numKeys+1 at the
 // call sites): setKey's return (a possibly shifted offset) is discarded
 // below, which is safe only because the spare keeps the node from ever
 // filling mid-build, so setKey never expands the node or moves containers.
@@ -252,7 +254,7 @@ func (acc *Accumulator) buildInto(ra *Bitmap, cards []int) {
 		var off uint64
 		if acc.keys[i] == 0 {
 			// Key 0's container pre-exists at exactly sz (layout sized it
-			// via sizeInitial) with its key slot already set — fill it in
+			// via sizeContainer0) with its key slot already set — fill it in
 			// place; appending would orphan it as dead space in ra.data.
 			off = ra.keys.val(0)
 		} else {

--- a/benchmark_opt_test.go
+++ b/benchmark_opt_test.go
@@ -488,3 +488,48 @@ func benchmark_Or_Conc(b *testing.B, concurrency int) {
 		}
 	}
 }
+
+// go test -v -bench BenchmarkFromSortedList -benchmem -run ^$ github.com/weaviate/sroar
+func BenchmarkFromSortedList(b *testing.B) {
+	genSeq := func(n int, stride uint64) []uint64 {
+		vals := make([]uint64, n)
+		for i := range vals {
+			vals[i] = uint64(i) * stride
+		}
+		return vals
+	}
+
+	for _, bc := range []struct {
+		name string
+		vals []uint64
+	}{
+		{"dense_1M", genSeq(1<<20, 1)},
+		{"dense_100k", genSeq(100_000, 1)},
+		{"dense_10k", genSeq(10_000, 1)},
+		{"dense_1k", genSeq(1_000, 1)},
+		{"sparse_100k", genSeq(100_000, 1000)},
+		{"sparse_10k", genSeq(10_000, 1000)},
+		{"verysparse_10k", genSeq(10_000, 1<<16)},
+	} {
+		b.Run(bc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				FromSortedList(bc.vals)
+			}
+		})
+		b.Run(bc.name+"/ToBuf", func(b *testing.B) {
+			var buf []byte
+			getBuf := func(sizeBytes int) []byte {
+				if cap(buf) < sizeBytes {
+					buf = make([]byte, sizeBytes)
+				}
+				return buf[:sizeBytes]
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				FromSortedListToBuf(bc.vals, getBuf)
+			}
+		})
+	}
+}

--- a/bitmap.go
+++ b/bitmap.go
@@ -97,14 +97,14 @@ func initBitmapToBuf(dst *Bitmap, buf []byte) *Bitmap {
 	// the bitmap operates on []uint16 (2 bytes per element).
 	buf = buf[:cap(buf)/2*2]
 
-	keysLen := calcInitialKeysLen(2)
-	if minLen := (keysLen + minContainerSize) * 2; minLen > len(buf) {
+	sizeKeys := calcSizeKeys(2)
+	if minLen := (sizeKeys + minContainerSize) * 2; minLen > len(buf) {
 		return initBitmapWithCap(dst, 2, minContainerSize, 0)
 	}
 
 	bufU16 := byteToUint16SliceUnsafe(buf)
 	clear(bufU16)
-	initBitmapCore(dst, keysLen, minContainerSize, bufU16)
+	initBitmapCore(dst, sizeKeys, minContainerSize, bufU16)
 	dst._ptr = buf
 	return dst
 }
@@ -112,32 +112,32 @@ func initBitmapToBuf(dst *Bitmap, buf []byte) *Bitmap {
 // initBitmapWithCap initializes dst over freshly allocated memory sized for
 // numKeys keys plus additionalCapacity; the heap fallback of the buffer-based
 // initializers. Returns dst.
-func initBitmapWithCap(dst *Bitmap, numKeys, initialContainerSize, additionalCapacity int) *Bitmap {
+func initBitmapWithCap(dst *Bitmap, numKeys, sizeContainer0, additionalCapacity int) *Bitmap {
 	if numKeys < 2 {
 		panic("Must contain at least two keys.")
 	}
-	keysLen := calcInitialKeysLen(numKeys)
-	buf := make([]uint16, keysLen+initialContainerSize+additionalCapacity)
-	return initBitmapCore(dst, keysLen, initialContainerSize, buf)
+	sizeKeys := calcSizeKeys(numKeys)
+	buf := make([]uint16, sizeKeys+sizeContainer0+additionalCapacity)
+	return initBitmapCore(dst, sizeKeys, sizeContainer0, buf)
 }
 
 // initBitmapCore lays out an empty bitmap — keys node plus the mandatory
 // key-0 container — over buf; every initializer funnels here. Returns dst.
-func initBitmapCore(dst *Bitmap, keysLen, initialContainerSize int, buf []uint16) *Bitmap {
-	*dst = Bitmap{data: buf[:keysLen]}
+func initBitmapCore(dst *Bitmap, sizeKeys, sizeContainer0 int, buf []uint16) *Bitmap {
+	*dst = Bitmap{data: buf[:sizeKeys]}
 	dst.keys = uint16To64SliceUnsafe(dst.data)
-	dst.keys.setNodeSize(keysLen)
+	dst.keys.setNodeSize(sizeKeys)
 
 	// Always generate a container for key = 0x00. Otherwise, node gets confused
 	// about whether a zero key is a new key or not.
-	offset := dst.newContainer(uint16(initialContainerSize))
+	offset := dst.newContainer(uint16(sizeContainer0))
 	// First two are for num keys. index=2 -> 0 key. index=3 -> offset.
 	dst.keys.setAt(indexNodeStart+1, offset)
 	dst.keys.setNumKeys(1)
 	return dst
 }
 
-func calcInitialKeysLen(numKeys int) int {
+func calcSizeKeys(numKeys int) int {
 	// Each key must also keep an offset. So, we need to double the number
 	// of uint64s allocated. Plus, we need to make space for the first 2
 	// uint64s to store the number of keys and node size.
@@ -147,24 +147,24 @@ func calcInitialKeysLen(numKeys int) int {
 // initBitmapToBufExact lays an empty bitmap for the given layout over a
 // caller-supplied buffer and returns dst backed by it. The buffer is
 // adopted at its full capacity, rounded down to an even number of bytes
-// since the bitmap operates on []uint16; a buffer smaller than need panics
+// since the bitmap operates on []uint16; a buffer smaller than sizeTotal panics
 // with the caller's name. The keys node is cleared so a dirty pooled
 // buffer cannot leak into the serialized form — every other exposed byte
 // is written by the container build. Shared by the exact-size ToBuf builds
 // (FromSortedList, Accumulator).
-func initBitmapToBufExact(name string, dst *Bitmap, buf []byte, keysLen, sizeInitial, need int) *Bitmap {
+func initBitmapToBufExact(name string, dst *Bitmap, buf []byte, sizeKeys, sizeContainer0, sizeTotal int) *Bitmap {
 	if dst == nil {
 		panic(name + ": get returned a nil *Bitmap")
 	}
 	buf = buf[:cap(buf)/2*2]
-	if len(buf)/2 < need {
-		// Report cap: it matches what the caller passed, and with need*2
+	if len(buf)/2 < sizeTotal {
+		// Report cap: it matches what the caller passed, and with sizeTotal*2
 		// always even the rounded-down len could only confuse.
-		panic(fmt.Sprintf("%s: buf too small: need %d bytes, got %d", name, need*2, cap(buf)))
+		panic(fmt.Sprintf("%s: buf too small: need %d bytes, got %d", name, sizeTotal*2, cap(buf)))
 	}
 	bufU16 := byteToUint16SliceUnsafe(buf)
-	clear(bufU16[:keysLen])
-	initBitmapCore(dst, keysLen, sizeInitial, bufU16)
+	clear(bufU16[:sizeKeys])
+	initBitmapCore(dst, sizeKeys, sizeContainer0, bufU16)
 	dst._ptr = buf // Keep a GC reference to buf, mirroring NewBitmapToBuf.
 	return dst
 }
@@ -458,8 +458,8 @@ func (ra *Bitmap) Set(x uint64) bool {
 // anything is allocated. The result is allocated fully sized in a single
 // step, like the Accumulator build.
 func FromSortedList(vals []uint64) *Bitmap {
-	newKeys, sizeInitial, sizeContainers := fromSortedLayout(vals)
-	ra := initBitmapWithCap(&Bitmap{}, newKeys+2, sizeInitial, sizeContainers)
+	numKeys, sizeContainer0, sizeOtherContainers := fromSortedLayout(vals)
+	ra := initBitmapWithCap(&Bitmap{}, numKeys+1, sizeContainer0, sizeOtherContainers)
 	return buildFromSortedInto(ra, vals)
 }
 
@@ -603,10 +603,10 @@ func (ra *Bitmap) RemoveRange(lo, hi uint64) {
 }
 
 func (ra *Bitmap) Reset() {
-	keysLen := calcInitialKeysLen(2)
-	ra.data = ra.data[:keysLen]
+	sizeKeys := calcSizeKeys(2)
+	ra.data = ra.data[:sizeKeys]
 	ra.keys = uint16To64SliceUnsafe(ra.data)
-	ra.keys.setNodeSize(keysLen)
+	ra.keys.setNodeSize(sizeKeys)
 
 	// Always generate a container for key = 0x00. Otherwise, node gets confused
 	// about whether a zero key is a new key or not.

--- a/bitmap.go
+++ b/bitmap.go
@@ -144,23 +144,29 @@ func calcInitialKeysLen(numKeys int) int {
 	return 4 * (2*numKeys + 2)
 }
 
-func (ra *Bitmap) initSpaceForKeys(N int) {
-	if N == 0 {
-		return
+// initBitmapToBufExact lays an empty bitmap for the given layout over a
+// caller-supplied buffer and returns dst backed by it. The buffer is
+// adopted at its full capacity, rounded down to an even number of bytes
+// since the bitmap operates on []uint16; a buffer smaller than need panics
+// with the caller's name. The keys node is cleared so a dirty pooled
+// buffer cannot leak into the serialized form — every other exposed byte
+// is written by the container build. Shared by the exact-size ToBuf builds
+// (FromSortedList, Accumulator).
+func initBitmapToBufExact(name string, dst *Bitmap, buf []byte, keysLen, sizeInitial, need int) *Bitmap {
+	if dst == nil {
+		panic(name + ": get returned a nil *Bitmap")
 	}
-	curSize := uint64(len(ra.keys) * 4) // U64 -> U16
-	bySize := uint64(N * 8)             // 2xU64 (key, value) -> 2x4xU16
-
-	// The following code is borrowed from setKey.
-	ra.scootRight(curSize, bySize)
-	ra.keys = uint16To64SliceUnsafe(ra.data[:curSize+bySize])
-	ra.keys.setNodeSize(int(curSize + bySize))
-	assert(1 == ra.keys.numKeys()) // This initialization assumes that the number of keys are 1.
-
-	// The containers have moved to the right bySize. So, update their offsets.
-	// Currently, there's only one container.
-	val := ra.keys.val(0)
-	ra.keys.setAt(valOffset(0), val+uint64(bySize))
+	buf = buf[:cap(buf)/2*2]
+	if len(buf)/2 < need {
+		// Report cap: it matches what the caller passed, and with need*2
+		// always even the rounded-down len could only confuse.
+		panic(fmt.Sprintf("%s: buf too small: need %d bytes, got %d", name, need*2, cap(buf)))
+	}
+	bufU16 := byteToUint16SliceUnsafe(buf)
+	clear(bufU16[:keysLen])
+	initBitmapCore(dst, keysLen, sizeInitial, bufU16)
+	dst._ptr = buf // Keep a GC reference to buf, mirroring NewBitmapToBuf.
+	return dst
 }
 
 // setKey sets a key and container offset.
@@ -447,60 +453,14 @@ func (ra *Bitmap) Set(x uint64) bool {
 	panic("we shouldn't reach here")
 }
 
+// FromSortedList builds a bitmap from a sorted list of values; duplicates
+// are allowed and deduplicated. It panics on unsorted input, before
+// anything is allocated. The result is allocated fully sized in a single
+// step, like the Accumulator build.
 func FromSortedList(vals []uint64) *Bitmap {
-	var arr []uint16
-	var hi, lastHi, off uint64
-
-	ra := NewBitmap()
-
-	if len(vals) == 0 {
-		return ra
-	}
-
-	// Set the keys beforehand so that we don't need to move a lot of memory because of adding keys.
-	var numKeys int
-	for _, x := range vals {
-		hi = x & mask
-		if hi != 0 && hi != lastHi {
-			numKeys++
-		}
-		lastHi = hi
-	}
-	ra.initSpaceForKeys(numKeys)
-
-	finalize := func(l []uint16, key uint64) {
-		if len(l) == 0 {
-			return
-		}
-		sz, typ := containerSizeForCard(len(l))
-		off = ra.newContainer(sz)
-		c := ra.getContainer(off)
-		c[indexSize] = sz
-		c[indexType] = typ
-		if typ == typeArray {
-			setCardinality(c, len(l))
-			copy(c[startIdx:], l)
-		} else {
-			for _, v := range l {
-				bitmap(c).add(v)
-			}
-		}
-		ra.setKey(key, off)
-	}
-
-	lastHi = 0
-	for _, x := range vals {
-		hi = x & mask
-		// Finalize the last container before proceeding ahead
-		if hi != 0 && hi != lastHi {
-			finalize(arr, lastHi)
-			arr = arr[:0]
-		}
-		arr = append(arr, uint16(x))
-		lastHi = hi
-	}
-	finalize(arr, lastHi)
-	return ra
+	newKeys, sizeInitial, sizeContainers := fromSortedLayout(vals)
+	ra := initBitmapWithCap(&Bitmap{}, newKeys+2, sizeInitial, sizeContainers)
+	return buildFromSortedInto(ra, vals)
 }
 
 // TODO: Potentially this can be optimized.

--- a/bitmap_opt.go
+++ b/bitmap_opt.go
@@ -3,6 +3,7 @@ package sroar
 import (
 	"fmt"
 	"math"
+	"math/bits"
 	"slices"
 	"sync"
 )
@@ -274,6 +275,220 @@ func containerSizeForCard(n int) (sz uint16, typ uint16) {
 		return uint16(compactedArraySize(n)), typeArray
 	}
 	return maxContainerSize, typeBitmap
+}
+
+// FromSortedListToBuf is FromSortedList building into a buffer obtained
+// from get — for callers that pool result memory. get is called exactly
+// once, with the required size in bytes — exact for duplicate-free input;
+// an upper bound when vals carries duplicates, up to one bitmap container
+// (~8 KB) larger per key segment whose duplicates collapse it below the
+// array threshold — and only after vals has passed the sortedness check.
+// Returning a buffer smaller than the requested size panics — the caller
+// was told how much is needed.
+// The buffer is adopted to its full capacity (rounded down to even), not
+// just its length, and may arrive dirty — the build writes every byte the
+// result exposes. It must not alias the memory backing vals: the build
+// writes containers while still reading later values. The returned bitmap
+// holds a reference to the buffer, so the buffer must not be reused until
+// the bitmap is released. Mutating the result stays within the buffer's
+// capacity until it needs to grow, at which point it migrates to the heap.
+func FromSortedListToBuf(vals []uint64, get func(sizeBytes int) []byte) *Bitmap {
+	return InitFromSortedListToBuf(vals, func(sizeBytes int) (*Bitmap, []byte) {
+		return &Bitmap{}, get(sizeBytes)
+	})
+}
+
+// InitFromSortedListToBuf is FromSortedListToBuf for callers that pool the
+// result Bitmap struct together with its buffer: get returns both —
+// typically from one pool entry — and the bitmap is built into them, so
+// building into pooled memory allocates nothing. The struct must be
+// non-nil; its previous fields are overwritten, never freed — it must not
+// own anything the caller still needs. A buffer smaller than the
+// requested size panics, as in FromSortedListToBuf.
+func InitFromSortedListToBuf(vals []uint64, get func(sizeBytes int) (*Bitmap, []byte)) *Bitmap {
+	newKeys, sizeInitial, sizeContainers := fromSortedLayout(vals)
+	// The +2 keys are the always-present key 0 and the spare
+	// buildFromSortedInto relies on.
+	keysLen := calcInitialKeysLen(newKeys + 2)
+	need := keysLen + sizeInitial + sizeContainers
+
+	dst, buf := get(need * 2)
+	initBitmapToBufExact("InitFromSortedListToBuf", dst, buf, keysLen, sizeInitial, need)
+	return buildFromSortedInto(dst, vals)
+}
+
+// fromSortedLayout is the counting pass shared by the FromSortedList
+// constructors: new keys and container sizes per key segment, panicking on
+// descending input. Containers are sized by segment length — for
+// duplicate-free input, the common case, that is the distinct cardinality
+// and the layout is final. Duplicates are discovered for free during the
+// fill, which corrects the affected containers in place (truncate or
+// rewrite, without moving them); keeping this pass oblivious to them
+// keeps it off the critical path. Key 0 is special-cased
+// like in Accumulator.layout: its slot and container always exist, so its
+// segment sizes the pre-created container via sizeInitial instead of
+// counting a new key.
+func fromSortedLayout(vals []uint64) (newKeys, sizeInitial, sizeContainers int) {
+	sizeInitial = minContainerSize
+	if len(vals) == 0 {
+		return
+	}
+
+	accountSeg := func(card int, key uint64) {
+		sz, _ := containerSizeForCard(card)
+		if key != 0 {
+			newKeys++
+			sizeContainers += int(sz)
+		} else {
+			sizeInitial = int(sz)
+		}
+	}
+	segKey := vals[0] & mask
+	segStart := 0
+	prev := vals[0]
+	for i := 1; i < len(vals); i++ {
+		x := vals[i]
+		if x < prev {
+			panic(fmt.Sprintf("FromSortedList: input not sorted at index %d (%d after %d)", i, x, prev))
+		}
+		prev = x
+		if key := x & mask; key != segKey {
+			accountSeg(i-segStart, segKey)
+			segStart, segKey = i, key
+		}
+	}
+	accountSeg(len(vals)-segStart, segKey)
+	return
+}
+
+// buildFromSortedInto builds the containers into ra, whose data array must
+// already have capacity for the full layout and whose keys node must be
+// sized with one spare slot beyond the result's keys (the newKeys+2 at the
+// call sites), so setKey never expands the node or moves containers.
+// Containers are first sized by segment length, matching fromSortedLayout;
+// when the fill finds duplicates, the just-filled container — still the
+// tail of ra.data — is truncated to its canonical size (or rewritten as
+// the array a bitmap collapses into) before the next append, so the final
+// layout always matches a duplicate-free build's. Only the padded
+// capacity remains. Returns ra.
+func buildFromSortedInto(ra *Bitmap, vals []uint64) *Bitmap {
+	if len(vals) == 0 {
+		return ra
+	}
+
+	// Every value of a segment shares one key, so the segment maps 1:1 to a
+	// container. The exact allocation guarantees the appends below never
+	// reallocate; containers are appended in ascending key order and never
+	// moved.
+	finalize := func(seg []uint64, key uint64) {
+		sz, typ := containerSizeForCard(len(seg))
+		var off uint64
+		if key == 0 {
+			// Key 0's container pre-exists at exactly sz — fill it in place;
+			// appending would orphan it as dead space in ra.data.
+			off = ra.keys.val(0)
+		} else {
+			off = ra.newContainerNoClr(sz)
+			ra.data[off] = sz
+		}
+		c := ra.data[off : off+uint64(sz)]
+		c[indexType] = typ
+		if typ == typeArray {
+			fillArrayContainer(ra, off, c, seg)
+		} else {
+			fillBitmapContainer(ra, off, c, seg)
+		}
+		if key != 0 {
+			ra.setKey(key, off)
+		}
+	}
+
+	segKey := vals[0] & mask
+	segStart := 0
+	for i, x := range vals {
+		if key := x & mask; key != segKey {
+			finalize(vals[segStart:i], segKey)
+			segStart, segKey = i, key
+		}
+	}
+	finalize(vals[segStart:], segKey)
+	return ra
+}
+
+// fillArrayContainer writes seg's distinct values into the array container
+// at off — the current tail of ra.data — truncating it to the size the
+// distinct count warrants when duplicates shrank the content.
+func fillArrayContainer(ra *Bitmap, off uint64, c []uint16, seg []uint64) {
+	card := dedupIntoArray(seg, c)
+	if card != len(seg) {
+		sz, _ := containerSizeForCard(card)
+		c = truncateTail(ra, off, sz)
+	}
+	setCardinality(c, card)
+	clear(c[int(startIdx)+card:])
+}
+
+// fillBitmapContainer fills the bitmap container at off — the current tail
+// of ra.data — from seg. When duplicates collapse the distinct count below
+// the array threshold, the container is rewritten in place as the array a
+// duplicate-free build would produce (from seg — the popcount is the last
+// read of the words, so they can be overwritten), and truncated.
+func fillBitmapContainer(ra *Bitmap, off uint64, c []uint16, seg []uint64) {
+	words := c[startIdx:]
+	clear(words)
+	// Values are ascending, so bits of one word arrive consecutively;
+	// accumulate them and write each word once. Duplicates need no
+	// handling here — OR-ing a bit twice sets it once — and the
+	// popcount below counts distinct values by construction.
+	wordIdx := uint16(seg[0]) >> 4
+	var word uint16
+	for _, v := range seg {
+		y := uint16(v)
+		if idx := y >> 4; idx != wordIdx {
+			words[wordIdx] = word
+			word = 0
+			wordIdx = idx
+		}
+		word |= bitmapMask[y&0xf]
+	}
+	words[wordIdx] = word
+	card := 0
+	for _, w := range uint16To64SliceUnsafe(words) {
+		card += bits.OnesCount64(w)
+	}
+	if newSz, newTyp := containerSizeForCard(card); newTyp == typeArray {
+		c = truncateTail(ra, off, newSz)
+		c[indexType] = newTyp
+		dedupIntoArray(seg, c)
+		clear(c[int(startIdx)+card:])
+	}
+	setCardinality(c, card)
+}
+
+// truncateTail shrinks the container at off — the current tail of
+// ra.data — to sz and returns it resliced; the freed space is surrendered
+// to the next append.
+func truncateTail(ra *Bitmap, off uint64, sz uint16) []uint16 {
+	ra.data = ra.data[:off+uint64(sz)]
+	c := ra.data[off:]
+	c[indexSize] = sz
+	return c
+}
+
+// dedupIntoArray writes seg's distinct values into c's array payload and
+// returns their count. prev starts unequal to every value
+// (^seg[0] != seg[0]), so the first value is never skipped as a duplicate.
+func dedupIntoArray(seg []uint64, c []uint16) (card int) {
+	prev := ^seg[0]
+	for _, v := range seg {
+		if v == prev {
+			continue
+		}
+		prev = v
+		c[int(startIdx)+card] = uint16(v)
+		card++
+	}
+	return card
 }
 
 // andNotResultSize returns the uint16s the result for source ac occupies in

--- a/bitmap_opt.go
+++ b/bitmap_opt.go
@@ -306,30 +306,30 @@ func FromSortedListToBuf(vals []uint64, get func(sizeBytes int) []byte) *Bitmap 
 // own anything the caller still needs. A buffer smaller than the
 // requested size panics, as in FromSortedListToBuf.
 func InitFromSortedListToBuf(vals []uint64, get func(sizeBytes int) (*Bitmap, []byte)) *Bitmap {
-	newKeys, sizeInitial, sizeContainers := fromSortedLayout(vals)
-	// The +2 keys are the always-present key 0 and the spare
-	// buildFromSortedInto relies on.
-	keysLen := calcInitialKeysLen(newKeys + 2)
-	need := keysLen + sizeInitial + sizeContainers
+	numKeys, sizeContainer0, sizeOtherContainers := fromSortedLayout(vals)
+	// +1 is the spare slot buildFromSortedInto relies on.
+	sizeKeys := calcSizeKeys(numKeys + 1)
+	sizeTotal := sizeKeys + sizeContainer0 + sizeOtherContainers
 
-	dst, buf := get(need * 2)
-	initBitmapToBufExact("InitFromSortedListToBuf", dst, buf, keysLen, sizeInitial, need)
+	dst, buf := get(sizeTotal * 2)
+	initBitmapToBufExact("InitFromSortedListToBuf", dst, buf, sizeKeys, sizeContainer0, sizeTotal)
 	return buildFromSortedInto(dst, vals)
 }
 
 // fromSortedLayout is the counting pass shared by the FromSortedList
-// constructors: new keys and container sizes per key segment, panicking on
-// descending input. Containers are sized by segment length — for
-// duplicate-free input, the common case, that is the distinct cardinality
-// and the layout is final. Duplicates are discovered for free during the
-// fill, which corrects the affected containers in place (truncate or
-// rewrite, without moving them); keeping this pass oblivious to them
-// keeps it off the critical path. Key 0 is special-cased
-// like in Accumulator.layout: its slot and container always exist, so its
-// segment sizes the pre-created container via sizeInitial instead of
-// counting a new key.
-func fromSortedLayout(vals []uint64) (newKeys, sizeInitial, sizeContainers int) {
-	sizeInitial = minContainerSize
+// constructors: the result's key count and container space, accumulated
+// per key segment, panicking on descending input. Containers are sized by segment
+// length — for duplicate-free input, the common case, that is the
+// distinct cardinality and the layout is final. Duplicates are discovered
+// for free during the fill, which corrects the affected containers in
+// place (truncate or rewrite, without moving them); keeping this pass
+// oblivious to them keeps it off the critical path. Key 0 is
+// special-cased like in Accumulator.layout: its slot and container always
+// exist — numKeys counts that slot up front, and its segment sizes the
+// pre-created container via sizeContainer0 instead of counting a key.
+func fromSortedLayout(vals []uint64) (numKeys, sizeContainer0, sizeOtherContainers int) {
+	numKeys = 1 // the key-0 slot every bitmap pre-creates
+	sizeContainer0 = minContainerSize
 	if len(vals) == 0 {
 		return
 	}
@@ -337,10 +337,10 @@ func fromSortedLayout(vals []uint64) (newKeys, sizeInitial, sizeContainers int) 
 	accountSeg := func(card int, key uint64) {
 		sz, _ := containerSizeForCard(card)
 		if key != 0 {
-			newKeys++
-			sizeContainers += int(sz)
+			numKeys++
+			sizeOtherContainers += int(sz)
 		} else {
-			sizeInitial = int(sz)
+			sizeContainer0 = int(sz)
 		}
 	}
 	segKey := vals[0] & mask
@@ -363,7 +363,7 @@ func fromSortedLayout(vals []uint64) (newKeys, sizeInitial, sizeContainers int) 
 
 // buildFromSortedInto builds the containers into ra, whose data array must
 // already have capacity for the full layout and whose keys node must be
-// sized with one spare slot beyond the result's keys (the newKeys+2 at the
+// sized with one spare slot beyond the result's keys (the numKeys+1 at the
 // call sites), so setKey never expands the node or moves containers.
 // Containers are first sized by segment length, matching fromSortedLayout;
 // when the fill finds duplicates, the just-filled container — still the
@@ -1194,12 +1194,12 @@ func (ra *Bitmap) FillUp(maxX uint64) {
 		if maxRemainingCount > 0 {
 			minimalContainersCount++
 		}
-		minimalKeysLen := calcInitialKeysLen(minimalContainersCount + 1)
-		minimalLen := minimalKeysLen + minimalContainersCount*maxContainerSize
+		minimalSizeKeys := calcSizeKeys(minimalContainersCount + 1)
+		minimalSizeTotal := minimalSizeKeys + minimalContainersCount*maxContainerSize
 
 		bm := &Bitmap{}
-		if minimalLen <= cap(ra.data) {
-			initBitmapCore(bm, minimalKeysLen, maxContainerSize, ra.data)
+		if minimalSizeTotal <= cap(ra.data) {
+			initBitmapCore(bm, minimalSizeKeys, maxContainerSize, ra.data)
 		} else {
 			initBitmapWithCap(bm, int(maxContainersCount)+1+1, maxContainerSize, int(maxContainersCount)*maxContainerSize)
 		}

--- a/bitmap_opt_test.go
+++ b/bitmap_opt_test.go
@@ -3897,3 +3897,317 @@ func TestCopresenceByMaskToBuf(t *testing.T) {
 		require.Equal(t, expected.ToArray(), got.ToArray())
 	})
 }
+
+func TestFromSortedList(t *testing.T) {
+	rnd := rand.New(rand.NewSource(1724861525311))
+
+	genSeq := func(n int, stride uint64) []uint64 {
+		vals := make([]uint64, n)
+		for i := range vals {
+			vals[i] = uint64(i) * stride
+		}
+		return vals
+	}
+	genRandom := func(n int, max int64) []uint64 {
+		unique := map[uint64]struct{}{}
+		for len(unique) < n {
+			unique[uint64(rnd.Int63n(max))] = struct{}{}
+		}
+		vals := make([]uint64, 0, n)
+		for v := range unique {
+			vals = append(vals, v)
+		}
+		slices.Sort(vals)
+		return vals
+	}
+
+	testCases := map[string][]uint64{
+		"empty":                         nil,
+		"single value":                  {7},
+		"few values in key 0":           {1, 2, 3},
+		"container boundaries":          {1, 2, 3, 1 << 20, 1<<20 + 1, 1 << 40},
+		"not starting at key 0":         {1 << 20, 1<<20 + 5, 1 << 33},
+		"array/bitmap threshold 2048":   genSeq(2048, 3),
+		"array/bitmap threshold 2049":   genSeq(2049, 3),
+		"one full container":            genSeq(65536, 1),
+		"dense across containers":       genSeq(1_000_000, 1),
+		"sparse arrays":                 genSeq(100_000, 1000),
+		"one value per container":       genSeq(1_000, 1<<16),
+		"random":                        genRandom(50_000, 1<<40),
+		"max uint64 values":             {1, math.MaxUint64 - 1, math.MaxUint64},
+		"last value of first container": {65534, 65535, 65536},
+	}
+
+	for name, vals := range testCases {
+		t.Run(name, func(t *testing.T) {
+			expected := NewBitmap()
+			for _, v := range vals {
+				expected.Set(v)
+			}
+			bm := FromSortedList(vals)
+			require.Equal(t, expected.GetCardinality(), bm.GetCardinality())
+			require.Equal(t, expected.ToArray(), bm.ToArray())
+
+			// Exact-size constructors share their layout: same content must
+			// serialize to the same bytes as the Accumulator build.
+			acc := NewAccumulator()
+			acc.Or(bm)
+			require.Equal(t, acc.Bitmap().ToBuffer(), bm.ToBuffer())
+
+			// The serialized form must survive a deserialize cycle.
+			rt := FromBuffer(bm.ToBuffer())
+			require.Equal(t, expected.GetCardinality(), rt.GetCardinality())
+			require.Equal(t, expected.ToArray(), rt.ToArray())
+
+			// ToBuf must produce the identical bitmap from a dirty,
+			// oversized buffer.
+			var askedBytes int
+			bmBuf := FromSortedListToBuf(vals, func(sizeBytes int) []byte {
+				askedBytes = sizeBytes
+				buf := make([]byte, sizeBytes+100)
+				for i := range buf {
+					buf[i] = 0xff
+				}
+				return buf
+			})
+			if !bm.IsEmpty() {
+				// The requested size is exactly what the result serializes to.
+				require.Equal(t, len(bm.ToBuffer()), askedBytes)
+			} else {
+				// Empty input still asks for a buffer (the minimal live
+				// bitmap); its exact size is an implementation detail.
+				require.Positive(t, askedBytes)
+			}
+			require.Equal(t, bm.GetCardinality(), bmBuf.GetCardinality())
+			require.Equal(t, bm.ToBuffer(), bmBuf.ToBuffer())
+		})
+	}
+}
+
+func TestFromSortedListPanicsOnUnsortedInput(t *testing.T) {
+	panics := map[string][]uint64{
+		"unsorted":               {1, 3, 2},
+		"unsorted at first pair": {3, 1},
+		"unsorted across key":    {1 << 20, 1},
+	}
+	for name, vals := range panics {
+		t.Run(name, func(t *testing.T) {
+			require.Panics(t, func() { FromSortedList(vals) })
+		})
+	}
+
+	tolerated := map[string]struct {
+		vals     []uint64
+		expected []uint64
+	}{
+		"duplicate":          {vals: []uint64{1, 2, 2}, expected: []uint64{1, 2}},
+		"duplicate at start": {vals: []uint64{0, 0, 1}, expected: []uint64{0, 1}},
+	}
+	for name, tc := range tolerated {
+		t.Run(name, func(t *testing.T) {
+			var bm *Bitmap
+			require.NotPanics(t, func() { bm = FromSortedList(tc.vals) })
+			require.Equal(t, tc.expected, bm.ToArray())
+		})
+	}
+}
+
+func TestFromSortedListToBufContract(t *testing.T) {
+	t.Run("panics on too small buffer", func(t *testing.T) {
+		require.Panics(t, func() {
+			FromSortedListToBuf([]uint64{1, 2, 3}, func(sizeBytes int) []byte {
+				return make([]byte, sizeBytes-2)
+			})
+		})
+	})
+
+	t.Run("input checked before get is called", func(t *testing.T) {
+		called := false
+		require.Panics(t, func() {
+			FromSortedListToBuf([]uint64{2, 1}, func(sizeBytes int) []byte {
+				called = true
+				return make([]byte, sizeBytes)
+			})
+		})
+		require.False(t, called)
+	})
+
+	t.Run("adopts full capacity of length limited buffer", func(t *testing.T) {
+		bm := FromSortedListToBuf([]uint64{1, 2, 3}, func(sizeBytes int) []byte {
+			return make([]byte, 0, sizeBytes)
+		})
+		require.Equal(t, []uint64{1, 2, 3}, bm.ToArray())
+	})
+
+	t.Run("init panics on nil struct from get", func(t *testing.T) {
+		require.PanicsWithValue(t, "InitFromSortedListToBuf: get returned a nil *Bitmap", func() {
+			InitFromSortedListToBuf([]uint64{1, 2, 3}, func(sizeBytes int) (*Bitmap, []byte) {
+				return nil, make([]byte, sizeBytes)
+			})
+		})
+	})
+
+	t.Run("init builds into provided struct", func(t *testing.T) {
+		reused := FromSortedList([]uint64{99, 100_000})
+		bm := InitFromSortedListToBuf([]uint64{1, 2, 3}, func(sizeBytes int) (*Bitmap, []byte) {
+			return reused, make([]byte, sizeBytes)
+		})
+		require.Same(t, reused, bm)
+		require.Equal(t, []uint64{1, 2, 3}, bm.ToArray())
+		require.Equal(t, FromSortedList([]uint64{1, 2, 3}).ToBuffer(), bm.ToBuffer())
+	})
+
+	t.Run("init allocates nothing with pooled struct and buffer", func(t *testing.T) {
+		vals := []uint64{1, 2, 3, 1 << 20, 1 << 40}
+		pooled := &Bitmap{}
+		buf := make([]byte, 1<<12)
+		get := func(sizeBytes int) (*Bitmap, []byte) {
+			return pooled, buf[:sizeBytes]
+		}
+		allocs := testing.AllocsPerRun(10, func() {
+			InitFromSortedListToBuf(vals, get)
+		})
+		require.Zero(t, allocs)
+	})
+}
+
+func TestFromSortedListDuplicates(t *testing.T) {
+	genDup := func(n int, stride uint64, repeat int) []uint64 {
+		vals := make([]uint64, 0, n*repeat)
+		for i := 0; i < n; i++ {
+			for j := 0; j < repeat; j++ {
+				vals = append(vals, uint64(i)*stride)
+			}
+		}
+		return vals
+	}
+
+	testCases := map[string]struct {
+		vals     []uint64
+		expected []uint64
+	}{
+		"duplicates in array container": {
+			vals:     []uint64{1, 1, 2, 3, 3, 3},
+			expected: []uint64{1, 2, 3},
+		},
+		"duplicates across container boundary": {
+			vals:     []uint64{1 << 16, 1 << 16, 1<<16 + 1},
+			expected: []uint64{1 << 16, 1<<16 + 1},
+		},
+		"all same value": {
+			vals:     genDup(1, 1, 5000),
+			expected: []uint64{0},
+		},
+		"duplicates in bitmap container": {
+			// 3000 distinct values repeated twice: a bitmap container whose
+			// cardinality counts distinct only.
+			vals: genDup(3000, 2, 2),
+			expected: func() []uint64 {
+				v := make([]uint64, 3000)
+				for i := range v {
+					v[i] = uint64(i) * 2
+				}
+				return v
+			}(),
+		},
+		"duplicates straddling bitmap threshold": {
+			// 1500 distinct values repeated twice: 3000 raw elements, but the
+			// container type follows the 1500 distinct — an array, same as a
+			// duplicate-free build.
+			vals: genDup(1500, 2, 2),
+			expected: func() []uint64 {
+				v := make([]uint64, 1500)
+				for i := range v {
+					v[i] = uint64(i) * 2
+				}
+				return v
+			}(),
+		},
+		"key 0 collapses then more keys follow": {
+			// Key 0's segment: 2500 distinct values duplicated to 5000 raw —
+			// the pre-created container is filled as a bitmap, then rewritten
+			// in place as an array; containers for higher keys must append
+			// correctly after the truncated tail.
+			vals: append(genDup(2500, 2, 2), 1<<16, 1<<20, 1<<40),
+			expected: func() []uint64 {
+				v := make([]uint64, 2500)
+				for i := range v {
+					v[i] = uint64(i) * 2
+				}
+				return append(v, 1<<16, 1<<20, 1<<40)
+			}(),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			bm := FromSortedList(tc.vals)
+			require.Equal(t, len(tc.expected), bm.GetCardinality())
+			require.Equal(t, tc.expected, bm.ToArray())
+
+			// Sizing by distinct count makes the layout independent of
+			// duplicate multiplicity and identical across the exact-size
+			// constructors.
+			require.Equal(t, FromSortedList(tc.expected).ToBuffer(), bm.ToBuffer())
+			acc := NewAccumulator()
+			acc.Or(bm)
+			require.Equal(t, acc.Bitmap().ToBuffer(), bm.ToBuffer())
+
+			// The fix-up must work identically inside an adopted buffer,
+			// where the requested size is an upper bound for duplicate
+			// input.
+			var askedBytes int
+			bmBuf := FromSortedListToBuf(tc.vals, func(sizeBytes int) []byte {
+				askedBytes = sizeBytes
+				buf := make([]byte, sizeBytes)
+				for i := range buf {
+					buf[i] = 0xff
+				}
+				return buf
+			})
+			require.GreaterOrEqual(t, askedBytes, len(bm.ToBuffer()))
+			require.Equal(t, bm.ToBuffer(), bmBuf.ToBuffer())
+		})
+	}
+}
+
+func TestFromSortedListToBufMutation(t *testing.T) {
+	vals := []uint64{1, 2, 3, 1 << 20}
+
+	var pool []byte
+	bm := InitFromSortedListToBuf(vals, func(sizeBytes int) (*Bitmap, []byte) {
+		pool = make([]byte, sizeBytes, sizeBytes+1024)
+		return &Bitmap{}, pool
+	})
+	oracle := NewBitmap()
+	for _, v := range vals {
+		oracle.Set(v)
+	}
+	require.NotNil(t, bm._ptr)
+
+	// Mutations that fit the buffer's spare capacity stay on it.
+	mutate := func(b *Bitmap) {
+		b.Set(4)
+		b.Set(1 << 21)
+		b.Remove(2)
+	}
+	mutate(bm)
+	mutate(oracle)
+	require.NotNil(t, bm._ptr)
+	require.Equal(t, oracle.ToArray(), bm.ToArray())
+
+	// Outgrowing the buffer migrates the bitmap to the heap.
+	for v := uint64(0); v < 100_000; v++ {
+		bm.Set(v)
+		oracle.Set(v)
+	}
+	require.Nil(t, bm._ptr)
+
+	// The buffer is then free for reuse: trashing it must not affect the
+	// bitmap.
+	for i := range pool {
+		pool[i] = 0xee
+	}
+	require.Equal(t, oracle.GetCardinality(), bm.GetCardinality())
+	require.Equal(t, oracle.ToArray(), bm.ToArray())
+}

--- a/keys.go
+++ b/keys.go
@@ -210,35 +210,36 @@ func (n node) getValue(k uint64) (uint64, bool) {
 
 // set returns true if it added a new key.
 func (n node) set(k, v uint64) bool {
+	var idx int
 	N := n.numKeys()
-	idx := n.search(k)
-	if idx == N {
-		n.setNumKeys(N + 1)
-		n.setAt(keyOffset(idx), k)
-		n.setAt(valOffset(idx), v)
-		return true
+	if N > 0 && k > n.key(N-1) {
+		// Ascending inserts append past the last key; skip the binary search.
+		idx = N
+	} else {
+		idx = n.search(k)
 	}
 
-	ki := n.key(idx)
-	if N == n.maxKeys() {
-		// This happens during split of non-root node, when we are updating the child pointer of
-		// right node. Hence, the key should already exist.
-		assert(ki == k)
+	if idx < N {
+		ki := n.key(idx)
+		if N == n.maxKeys() {
+			// This happens during split of non-root node, when we are updating the child pointer of
+			// right node. Hence, the key should already exist.
+			assert(ki == k)
+		}
+		if ki == k {
+			n.setAt(valOffset(idx), v)
+			return false
+		}
+		assert(ki > k)
+		// Found the first entry which is greater than k. So, we need to fit k
+		// just before it. For that, we should move the rest of the data in the
+		// node to the right to make space for k.
+		n.moveRight(idx)
 	}
-	if ki == k {
-		n.setAt(valOffset(idx), v)
-		return false
-	}
-	assert(ki > k)
-	// Found the first entry which is greater than k. So, we need to fit k
-	// just before it. For that, we should move the rest of the data in the
-	// node to the right to make space for k.
-	n.moveRight(idx)
 	n.setNumKeys(N + 1)
 	n.setAt(keyOffset(idx), k)
 	n.setAt(valOffset(idx), v)
 	return true
-	// panic("shouldn't reach here")
 }
 
 func (n node) updateOffsets(beyond, by uint64, add bool) {


### PR DESCRIPTION
## Motivation

`FromSortedList` built its result incrementally — repeated grows and container moves added up to 28 allocs/op — and duplicate values silently corrupted array containers. This PR rebuilds it around exact sizing: a counting pass determines the complete layout, then a fill pass builds into one exact-size allocation, optionally into pooled memory via new `ToBuf` variants; duplicate corruption is fixed along the way.

Dense 1M: 2.8ms → 1.3ms (~2.2x). One key per container (10k keys): 198µs → 104µs. Sparse: 10–20% faster. Allocations: 28 → 2 (1 with `ToBuf`, 0 with a warm `InitToBuf` pool).

## Approach

Two passes: `fromSortedLayout` counts keys and container space (panicking on unsorted input before anything is allocated), `buildFromSortedInto` fills containers in ascending key order — appends never reallocate, containers never move. Duplicates are detected for free during the fill and corrected in place: the just-filled container is still the tail of `ra.data`, so it is truncated (or rewritten as an array when a bitmap collapses below the threshold) before the next append. The resulting layout is canonical — byte-identical to a duplicate-free build of the same distinct values.

`FromSortedListToBuf` / `InitFromSortedListToBuf` build into a buffer obtained from a `get` callback: called exactly once, with the required byte size, only after the sortedness check; an undersized buffer panics; the buffer is adopted dirty at full capacity. For duplicate input the requested size is an upper bound.

Second commit: mechanical size-naming unification (`sizeKeys` / `sizeContainer0` / `sizeOtherContainers` / `sizeTotal`, `numKeys + 1` spare-slot arithmetic). Third commit (from profiling): append fast path in `node.set` — ascending inserts skip the per-key binary search; out-of-order inserts pay one predicted-not-taken compare.

## Key areas for review

- `bitmap_opt.go:buildFromSortedInto` + `fillBitmapContainer` — the tail-truncation invariant, and the bitmap→array rewrite sourcing from `seg` after the popcount (the last read of the words)
- `bitmap.go:initBitmapToBufExact` — the fix-up also runs inside adopted, possibly dirty pooled buffers
- `keys.go:node.set` — fast-path equivalence: `k` above the last key implies `search` returns `N`; equal-key updates and out-of-order inserts still take the search path
- `accumulator.go` — shared-helper extraction only; output verified bit-for-bit against main

Behavioral change: unsorted input panics (with the offending index) instead of silently corrupting; duplicates now produce a correct, canonical bitmap. The documented contract — sorted input — behaves as before.

## Testing

Table-driven tests across container boundaries, the 2048/2049 threshold, dense/sparse/random layouts and `MaxUint64`; panic cases; duplicate cases asserting byte equality with duplicate-free builds; `ToBuf` contract (exact size, undersized panic, dirty adoption) and post-build mutation incl. pooled-buffer growth migration; benchmarks as above.
